### PR TITLE
Require Geckolib dependency in mods metadata

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,8 +20,8 @@ versionRange="${minecraft_version_range}"
 ordering="NONE"
 side="BOTH"
 [[dependencies.${mod_id}]]
-modId="geckolib3"
-mandatory=false
+modId="geckolib"
+mandatory=true
 versionRange="[4.0.0,)"
 ordering="NONE"
-side="CLIENT"
+side="BOTH"


### PR DESCRIPTION
## Summary
- update the mods.toml dependency entry to require Geckolib on both the client and server

## Testing
- `gradle --console plain build` *(fails: missing Minecraft dependencies in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e05b79626c8325a18b5263c0bf09c5