### PR TITLE
Fix railgun firing by using held stack

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/network/C2S_RequestFire.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/network/C2S_RequestFire.java
@@ -27,18 +27,22 @@ public record C2S_RequestFire(BlockPos target) {
                 return;
             }
 
-            ItemStack stack = player.getUseItem();
-            if (!(stack.getItem() instanceof OrbitalRailgunItem railgun)) {
-                return;
+            ItemStack stack = player.getMainHandItem();
+            OrbitalRailgunItem railgun;
+            if (stack.getItem() instanceof OrbitalRailgunItem mainHandRailgun) {
+                railgun = mainHandRailgun;
+            } else {
+                stack = player.getOffhandItem();
+                if (stack.getItem() instanceof OrbitalRailgunItem offhandRailgun) {
+                    railgun = offhandRailgun;
+                } else {
+                    return;
+                }
             }
 
             if (player.getCooldowns().isOnCooldown(railgun)) {
                 return;
             }
-
-//            if (!player.isUsingItem()) {
-//                return;
-//            }
 
             railgun.applyCooldown(player);
             OrbitalRailgunStrikeManager.startStrike(player, packet.target);


### PR DESCRIPTION
## Summary
- ensure the server packet handler searches the player's hands for the orbital railgun before firing
- reapply the cooldown through the railgun item and start the strike once validated

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68e06981808c8325a3d8791990041d98