### PR TITLE
Remove redundant model-view upload for railgun shaders

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/railgun/PostChainManager.java
@@ -145,7 +145,6 @@ public class PostChainManager implements ResourceManagerReloadListener {
             }
 
             setMatrix(effect, "InverseTransformMatrix", inverse);
-            setMatrix(effect, "ModelViewMat", modelView);
             setVec3(effect, "CameraPosition", cameraPos);
             setVec3(effect, "BlockPosition", blockPos);
             setFloat(effect, "iTime", time);


### PR DESCRIPTION
## Summary
- stop uploading the model-view matrix to the post-process shader so the inverse transform is only applied once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e074f3effc832585db1f46cfc1e125