### PR TITLE
Restore model view uniform for railgun shader

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/railgun/PostChainManager.java
@@ -145,6 +145,7 @@ public class PostChainManager implements ResourceManagerReloadListener {
             }
 
             setMatrix(effect, "InverseTransformMatrix", inverse);
+            setMatrix(effect, "ModelViewMat", modelView);
             setVec3(effect, "CameraPosition", cameraPos);
             setVec3(effect, "BlockPosition", blockPos);
             setFloat(effect, "iTime", time);


### PR DESCRIPTION
## Summary
- restore the ModelViewMat uniform upload so the post-processing shader gets the camera transform

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e076ebcdc4832598fea7f414dfd2ab