### PR TITLE
Fix inverse transform matrix for orbital strike post chain

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/railgun/PostChainManager.java
@@ -133,7 +133,7 @@ public class PostChainManager implements ResourceManagerReloadListener {
         }
 
         Matrix4f modelView = new Matrix4f(RenderSystem.getModelViewMatrix());
-        Matrix4f inverse = new Matrix4f(RenderSystem.getProjectionMatrix()).mul(modelView).invert();
+        Matrix4f inverse = new Matrix4f(RenderSystem.getProjectionMatrix()).invert();
         Vec3 cameraPos = minecraft.gameRenderer.getMainCamera().getPosition();
         RailgunState state = RailgunState.getInstance();
         float distance = guiPass ? state.getHitDistance() : (float) cameraPos.distanceTo(blockPos);


### PR DESCRIPTION
## Summary
- update the inverse transform uniform to invert only the projection matrix so it matches the shader expectation

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e079db2b048325ac73e2c69bb2b424