### PR TITLE
Cache render matrices for post-processing

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/ClientEvents.java
@@ -74,9 +74,9 @@ public final class ClientEvents {
     @SubscribeEvent
     public static void onRenderStage(RenderLevelStageEvent event) {
         if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
-            PostChainManager.getInstance().processWorld(event.getPartialTick());
+            PostChainManager.getInstance().processWorld(event);
         } else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_LEVEL) {
-            PostChainManager.getInstance().processGui(event.getPartialTick());
+            PostChainManager.getInstance().processGui(event);
         }
     }
 }


### PR DESCRIPTION
## Summary
- pass the RenderLevelStageEvent through ClientEvents so PostChainManager has full context
- cache the camera pose during the world render pass and reuse it for uniform uploads
- drive both world and GUI post chains from the cached matrices and camera position

## Testing
- `./gradlew build` *(fails: gradlew script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e07e3765ac8325b32cfe5f94130db1