### PR TITLE
Add selection active uniform to GUI shader

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/ClientEvents.java
@@ -231,6 +231,7 @@ public final class ClientEvents {
             setFloat(effect, "Distance", distance);
             setFloat(effect, "IsBlockHit", isBlockHit);
             setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
+            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
             setInt(effect, "HitKind", state.getHitKind().ordinal());
         }
     }

--- a/src/main/resources/assets/orbital_railgun/shaders/program/gui.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/gui.fsh
@@ -11,6 +11,7 @@ uniform vec3 CameraPosition;
 
 uniform float IsBlockHit;
 uniform vec3 BlockPosition;
+uniform float SelectionActive;
 
 const vec3 red = 2. * vec3(0.878, 0.427, 0.427);
 const vec3 green = 2. * vec3(0.13, 0.65, 0.23);
@@ -61,7 +62,7 @@ vec3 renderUi(vec3 original, float dist) {
     float glitch = 1. + 0.2 * pcg_hash(uint(round((texCoord.x + texCoord.y * viewHeight) * viewWidth) + round(iTime * viewWidth * viewHeight)));
     overlay *= glitch;
 
-    return mix(original, overlay, threshold);
+    return mix(original, overlay, threshold * SelectionActive);
 }
 
 vec2 raycast(vec3 point, vec3 dir) {

--- a/src/main/resources/assets/orbital_railgun/shaders/program/gui.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/gui.json
@@ -20,6 +20,7 @@
     { "name": "CameraPosition",       "type": "float",     "count": 3,  "values": [ 0.0, 0.0, 0.0 ] },
     { "name": "IsBlockHit",       "type": "float",     "count": 1,  "values": [ 0.0 ] },
     { "name": "BlockPosition",       "type": "float",     "count": 3,  "values": [ 0.0, 0.0, 0.0 ] },
-    { "name": "iTime",       "type": "float",     "count": 1,  "values": [ 0.0 ] }
+    { "name": "iTime",       "type": "float",     "count": 1,  "values": [ 0.0 ] },
+    { "name": "SelectionActive",       "type": "float",     "count": 1,  "values": [ 0.0 ] }
   ]
 }


### PR DESCRIPTION
## Summary
- add a SelectionActive uniform to the client railgun post-processing passes
- declare the SelectionActive uniform in the GUI shader program definition
- gate the shader overlay mix on SelectionActive so the selection UI disappears after firing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0abd6d15083258f92c9af50e55845