### PR TITLE
Adjust shockwave blending for strike shader

### DIFF
--- a/src/main/resources/assets/orbital_railgun/shaders/program/strike.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/strike.fsh
@@ -154,6 +154,8 @@ void main() {
 
     threshold *= 1. - pow(clamp(iTime / endTime - 1., 0., 1.), 2.);
     vec3 shockwave_color = mix(blue, vec3(1.), clamp(iTime / endTime - 1., 0., 1.));
+    float shock = shockwave(hit_point);
+    vec3 tinted = mix(original, original * shock * shockwave_color, threshold);
 
-    fragColor = vec4(mix(original * shockwave(end_point) * shockwave_color, vec3(col), threshold), 1.);
+    fragColor = vec4(mix(tinted, vec3(col), threshold), 1.);
 }


### PR DESCRIPTION
## Summary
- derive the strike shockwave tint from the hit point instead of the end point
- blend the shockwave tint with the original color using the threshold so non-hit pixels stay untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0afa191d083259c82b3001f8e0bcc