### PR TITLE
Use manual ray cast for railgun targeting

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/client/railgun/RailgunState.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/railgun/RailgunState.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
@@ -103,9 +104,15 @@ public final class RailgunState {
     }
 
     private void updateHitInformation(Minecraft minecraft, LocalPlayer player) {
-        HitResult result = minecraft.hitResult;
-        if (result == null) {
-            result = player.pick(300.0D, 1.0F, false);
+        HitResult result = null;
+        Level level = minecraft.level;
+        if (level != null) {
+            Vec3 start = player.getEyePosition(1.0F);
+            Vec3 direction = player.getViewVector(1.0F);
+            double distance = Math.max(1.0D, level.getWorldBorder().getSize() / 2.0D);
+            Vec3 end = start.add(direction.scale(distance));
+            ClipContext context = new ClipContext(start, end, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player);
+            result = level.clip(context);
         }
 
         currentHit = result;


### PR DESCRIPTION
## Summary
- replace reliance on Minecraft's cached hit result with a manual ray cast for the railgun HUD
- compute the ray from the player's eye position toward their view direction out to the world border radius
- remove the old short-distance fallback and store the new hit result for HUD usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b9b4ba0c83258aa443a0b13a735a