### PR TITLE
Enable chromatic highlight during aiming

### DIFF
--- a/src/main/resources/assets/orbital_railgun/shaders/program/chromatic_abjuration.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/chromatic_abjuration.fsh
@@ -7,6 +7,8 @@ uniform vec3 BlockPosition;
 
 uniform float iTime;
 uniform float StrikeActive;
+uniform float SelectionActive;
+uniform float IsBlockHit;
 
 in vec2 texCoord;
 in float viewHeight;
@@ -22,7 +24,7 @@ void main() {
     float frameTimeCounter = max(iTime - 37., 0.);
 
     vec3 original = texture(DiffuseSampler, texCoord).rgb;
-    if (StrikeActive < 0.5) {
+    if (StrikeActive < 0.5 && SelectionActive < 0.5) {
         fragColor = vec4(original, 1.0);
         return;
     }

--- a/src/main/resources/assets/orbital_railgun/shaders/program/chromatic_abjuration.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/chromatic_abjuration.json
@@ -18,6 +18,8 @@
     { "name": "CameraPosition",       "type": "float",     "count": 3,  "values": [ 0.0, 0.0, 0.0 ] },
     { "name": "BlockPosition",       "type": "float",     "count": 3,  "values": [ 0.0, 0.0, 0.0 ] },
     { "name": "iTime",       "type": "float",     "count": 1,  "values": [ 0.0 ] },
-    { "name": "StrikeActive",       "type": "float",     "count": 1,  "values": [ 0.0 ] }
+    { "name": "StrikeActive",       "type": "float",     "count": 1,  "values": [ 0.0 ] },
+    { "name": "SelectionActive",       "type": "float",     "count": 1,  "values": [ 0.0 ] },
+    { "name": "IsBlockHit",       "type": "float",     "count": 1,  "values": [ 0.0 ] }
   ]
 }


### PR DESCRIPTION
## Summary
- add selection-related uniforms to the chromatic abjuration shader program configuration
- allow the chromatic fragment shader to render when either strike or selection state is active

## Testing
- ./gradlew runClient *(fails: Gradle wrapper script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c2bc3a3883258bfdd07c77b544a0