### PR TITLE
Remove unused ModelViewMat uniform from chromatic abjuration shader

### DIFF
--- a/src/main/resources/assets/orbital_railgun/shaders/program/chromatic_abjuration.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/chromatic_abjuration.json
@@ -12,7 +12,6 @@
   ],
   "uniforms": [
     { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
-    { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
     { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
 
     { "name": "CameraPosition",       "type": "float",     "count": 3,  "values": [ 0.0, 0.0, 0.0 ] },


### PR DESCRIPTION
## Summary
- remove the unused `ModelViewMat` uniform from the chromatic abjuration shader definition so that only consumed uniforms remain

## Testing
- gradle build

------
https://chatgpt.com/codex/tasks/task_e_68e1471254c48325be427e7089675101