### PR TITLE
Handle missing render target when applying railgun uniforms

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -225,8 +225,13 @@ public final class ClientEvents {
         }
 
         Minecraft minecraft = Minecraft.getInstance();
-        float width = minecraft.getWindow().getWidth();
-        float height = minecraft.getWindow().getHeight();
+        RenderTarget renderTarget = minecraft.getMainRenderTarget();
+        if (renderTarget == null) {
+            return;
+        }
+
+        float width = renderTarget.viewWidth > 0 ? renderTarget.viewWidth : renderTarget.width;
+        float height = renderTarget.viewHeight > 0 ? renderTarget.viewHeight : renderTarget.height;
 
         for (PostPass pass : passes) {
             EffectInstance effect = pass.getEffect();


### PR DESCRIPTION
## Summary
- guard against a null main render target when applying railgun post-process uniforms
- derive the OutSize uniform from the active render target dimensions so every pass receives accurate buffer sizes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15fdb8ed48325a1bf287d98804a66