### PR TITLE
Fix railgun shader OutSize to use render target backing dimensions

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -230,8 +230,8 @@ public final class ClientEvents {
             return;
         }
 
-        float width = renderTarget.viewWidth > 0 ? renderTarget.viewWidth : renderTarget.width;
-        float height = renderTarget.viewHeight > 0 ? renderTarget.viewHeight : renderTarget.height;
+        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
+        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
 
         for (PostPass pass : passes) {
             EffectInstance effect = pass.getEffect();


### PR DESCRIPTION
## Summary
- ensure orbital railgun post effect shaders derive OutSize from the render target backing dimensions
- keep a fallback to logical view size when backing dimensions are unavailable

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e163076d308325b14fefe9688806a5