### PR TITLE
Add Oculus/Iris shaderpack compatibility overlay

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Orbital Railgun Forge
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.0.1
+mod_version=1.0.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
@@ -1,5 +1,6 @@
 package net.tysontheember.orbitalrailgun;
 
+import net.tysontheember.orbitalrailgun.client.config.ClientConfig;
 import net.tysontheember.orbitalrailgun.config.OrbitalRailgunConfig;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.Network;
@@ -10,9 +11,9 @@ import net.minecraft.world.item.Rarity;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
@@ -37,6 +38,7 @@ public class ForgeOrbitalRailgunMod {
         modBus.addListener(this::onCommonSetup);
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, OrbitalRailgunConfig.COMMON_SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
 
         OrbitalRailgunStrikeManager.register();
     }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -455,18 +455,6 @@ public final class ClientEvents {
                 uTime.set(timeSeconds);
             }
 
-            float phaseSeconds = strikeActive ? state.getStrikeSeconds(partialTick) : state.getChargeSeconds(partialTick);
-            Uniform uPhase = safeGetUniform(compatOverlayEffect, "uPhaseSeconds");
-            if (uPhase != null) {
-                uPhase.set(phaseSeconds);
-            }
-
-            int hitKind = state.getHitKind().ordinal();
-            Uniform uHitKind = safeGetUniform(compatOverlayEffect, "HitKind");
-            if (uHitKind != null) {
-                uHitKind.set(hitKind);
-            }
-
             Uniform uStrike = safeGetUniform(compatOverlayEffect, "StrikeActive");
             if (uStrike != null) {
                 uStrike.set(strikeActive ? 1.0F : 0.0F);

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/compat/OculusCompat.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/compat/OculusCompat.java
@@ -1,0 +1,37 @@
+package net.tysontheember.orbitalrailgun.client.compat;
+
+import net.minecraftforge.fml.ModList;
+
+public final class OculusCompat {
+    private static boolean checked;
+    private static boolean active;
+
+    /** refresh detection cheaply once per client tick */
+    public static void tick() {
+        checked = false;
+    }
+
+    public static boolean isShaderpackActive() {
+        if (!checked) {
+            checked = true;
+            active = detect();
+        }
+        return active;
+    }
+
+    private static boolean detect() {
+        if (!(ModList.get().isLoaded("oculus") || ModList.get().isLoaded("iris"))) {
+            return false;
+        }
+        try {
+            Class<?> api = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            Object instance = api.getMethod("getInstance").invoke(null);
+            Object result = api.getMethod("isShaderPackInUse").invoke(instance);
+            return result instanceof Boolean && (Boolean) result;
+        } catch (Throwable throwable) {
+            return false;
+        }
+    }
+
+    private OculusCompat() {}
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/config/ClientConfig.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/config/ClientConfig.java
@@ -1,0 +1,32 @@
+package net.tysontheember.orbitalrailgun.client.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public final class ClientConfig {
+    public static final ForgeConfigSpec SPEC;
+    public static final ForgeConfigSpec.BooleanValue COMPAT_DISABLE_WITH_SHADERPACK;
+    public static final ForgeConfigSpec.BooleanValue COMPAT_OVERLAY_WITH_SHADERPACK;
+    public static final ForgeConfigSpec.BooleanValue COMPAT_FORCE_VANILLA_POSTCHAIN;
+    public static final ForgeConfigSpec.BooleanValue COMPAT_LOG_IRIS_STATE;
+
+    static {
+        ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+        builder.push("compat");
+        COMPAT_DISABLE_WITH_SHADERPACK = builder
+                .comment("Skip PostChain when Oculus/Iris shaderpack is active.")
+                .define("disableWithShaderpack", true);
+        COMPAT_OVERLAY_WITH_SHADERPACK = builder
+                .comment("Render a GUI overlay effect when shaderpack compatibility mode is active.")
+                .define("overlayWithShaderpack", true);
+        COMPAT_FORCE_VANILLA_POSTCHAIN = builder
+                .comment("Force PostChain even with shaderpack (debug).")
+                .define("forceVanillaPostChain", false);
+        COMPAT_LOG_IRIS_STATE = builder
+                .comment("Log shaderpack detection once per reload/world join.")
+                .define("logIrisState", true);
+        builder.pop();
+        SPEC = builder.build();
+    }
+
+    private ClientConfig() {}
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -7,6 +7,8 @@ version="${mod_version}"
 displayName="${mod_name}"
 authors="${mod_authors}"
 description='''${mod_description}'''
+suggests=["oculus"]
+# Changelog: Add Oculus/Iris compatibility overlay (no PostChain with shaderpacks).
 [[dependencies.${mod_id}]]
 modId="forge"
 mandatory=true

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
@@ -1,16 +1,15 @@
 #version 150
 in vec2 vUV;
 uniform float uTime;
-uniform float uPhaseSeconds;
 uniform float StrikeActive;
 uniform float SelectionActive;
-uniform int   HitKind;
 out vec4 FragColor;
 void main() {
   vec2 uv = vUV * 2.0 - 1.0;
   float r = length(uv);
   float vign = smoothstep(1.2, 0.25, r);
-  float pulse = 0.5 + 0.5 * sin((uTime + uPhaseSeconds) * 2.2);
-  float a = (1.0 - vign) * 0.35 * pulse * max(SelectionActive, StrikeActive);
-  FragColor = vec4(1.0, 0.0, 1.0, a);
+  float pulse = 0.5 + 0.5 * sin(uTime * 2.2);
+  float active = max(StrikeActive, SelectionActive);
+  float alpha = (1.0 - vign) * 0.35 * pulse * active;
+  FragColor = vec4(1.0, 0.0, 1.0, alpha);
 }

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
@@ -1,0 +1,16 @@
+#version 150
+in vec2 vUV;
+uniform float uTime;
+uniform float uPhaseSeconds;
+uniform float StrikeActive;
+uniform float SelectionActive;
+uniform int   HitKind;
+out vec4 FragColor;
+void main() {
+  vec2 uv = vUV * 2.0 - 1.0;
+  float r = length(uv);
+  float vign = smoothstep(1.2, 0.25, r);
+  float pulse = 0.5 + 0.5 * sin((uTime + uPhaseSeconds) * 2.2);
+  float a = (1.0 - vign) * 0.35 * pulse * max(SelectionActive, StrikeActive);
+  FragColor = vec4(1.0, 0.0, 1.0, a);
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.json
@@ -7,8 +7,6 @@
   "uniforms": [
     { "name":"OutSize",         "type":"float", "count":2, "values":[1.0, 1.0] },
     { "name":"uTime",           "type":"float", "count":1, "values":[0.0] },
-    { "name":"uPhaseSeconds",   "type":"float", "count":1, "values":[0.0] },
-    { "name":"HitKind",         "type":"int",   "count":1, "values":[0]   },
     { "name":"StrikeActive",    "type":"float", "count":1, "values":[0.0] },
     { "name":"SelectionActive", "type":"float", "count":1, "values":[0.0] }
   ]

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.json
@@ -1,0 +1,15 @@
+{
+  "blend": { "func": "add", "srcrgb": "srcalpha", "dstrgb": "1-srcalpha" },
+  "vertex":   "orbital_railgun:compat_overlay",
+  "fragment": "orbital_railgun:compat_overlay",
+  "samplers": [],
+  "attributes": ["Position","UV0"],
+  "uniforms": [
+    { "name":"OutSize",         "type":"float", "count":2, "values":[1.0, 1.0] },
+    { "name":"uTime",           "type":"float", "count":1, "values":[0.0] },
+    { "name":"uPhaseSeconds",   "type":"float", "count":1, "values":[0.0] },
+    { "name":"HitKind",         "type":"int",   "count":1, "values":[0]   },
+    { "name":"StrikeActive",    "type":"float", "count":1, "values":[0.0] },
+    { "name":"SelectionActive", "type":"float", "count":1, "values":[0.0] }
+  ]
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.vsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.vsh
@@ -1,0 +1,10 @@
+#version 150
+in vec3 Position;
+in vec2 UV0;
+uniform vec2 OutSize;
+out vec2 vUV;
+void main() {
+  vUV = UV0;
+  vec2 ndc = (Position.xy / OutSize) * 2.0 - 1.0;
+  gl_Position = vec4(ndc, 0.0, 1.0);
+}


### PR DESCRIPTION
## Summary
- add Oculus/Iris shaderpack detection and client configuration toggles
- render a GUI overlay shader when shaderpacks are active and fall back to PostChain when not
- register overlay shader resources and bump mod metadata to advertise the compatibility

## Testing
- `./gradlew build` *(fails: wrapper script missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e18adb7ddc8325a6c2666185fc1f19