### PR TITLE
Add shader pack compatibility pipeline

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
@@ -37,6 +37,7 @@ public class ForgeOrbitalRailgunMod {
         modBus.addListener(this::onCommonSetup);
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, OrbitalRailgunConfig.COMMON_SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, OrbitalRailgunConfig.CLIENT_SPEC);
 
         OrbitalRailgunStrikeManager.register();
     }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -1,22 +1,14 @@
 package net.tysontheember.orbitalrailgun.client;
 
-import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.railgun.PostChainManager;
 import net.tysontheember.orbitalrailgun.client.railgun.RailgunState;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.C2S_RequestFire;
 import net.tysontheember.orbitalrailgun.network.Network;
-import com.mojang.blaze3d.shaders.Uniform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.EffectInstance;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.client.renderer.PostPass;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
-import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -31,109 +23,31 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import org.joml.Matrix4f;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = ForgeOrbitalRailgunMod.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ClientEvents {
-    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
-    private static final Field PASSES_FIELD = findPassesField();
-    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
-            ForgeOrbitalRailgunMod.id("strike"),
-            ForgeOrbitalRailgunMod.id("gui")
-    );
-
-    private static PostChain railgunChain;
-    private static boolean chainReady;
-    private static int chainWidth = -1;
-    private static int chainHeight = -1;
-
     private static boolean attackWasDown;
 
     static {
-        if (PASSES_FIELD != null) {
-            PASSES_FIELD.setAccessible(true);
-        } else {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to locate orbital railgun post chain passes field");
-        }
         FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEvents::onRegisterReloadListeners);
     }
 
     private ClientEvents() {}
 
     private static void onRegisterReloadListeners(RegisterClientReloadListenersEvent event) {
-        event.registerReloadListener(new SimplePreparableReloadListener<Void>() {
-            @Override
-            protected Void prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
-                return null;
-            }
-
-            @Override
-            protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
-                ClientEvents.reloadChain(resourceManager);
-            }
-        });    }
-
-    private static void reloadChain(ResourceManager resourceManager) {
-        Minecraft minecraft = Minecraft.getInstance();
-        closeChain();
-        if (minecraft.getMainRenderTarget() == null) {
-            chainReady = false;
-            return;
-        }
-
-        try {
-            railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, minecraft.getMainRenderTarget(), RAILGUN_CHAIN_ID);
-            chainReady = true;
-            chainWidth = -1;
-            chainHeight = -1;
-            resizeChain(minecraft);
-        } catch (IOException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
-            chainReady = false;
-            closeChain();
-        }
-    }
-
-    private static void resizeChain(Minecraft minecraft) {
-        if (railgunChain == null) {
-            return;
-        }
-        RenderTarget mainTarget = minecraft.getMainRenderTarget();
-        if (mainTarget == null) {
-            return;
-        }
-        int width = mainTarget.width;
-        int height = mainTarget.height;
-        if (width == chainWidth && height == chainHeight) {
-            return;
-        }
-        railgunChain.resize(width, height);
-        chainWidth = width;
-        chainHeight = height;
+        PostChainManager.registerReloadListener(event);
     }
 
     @SubscribeEvent
     public static void onScreenRender(ScreenEvent.Render.Post event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        resizeChain(Minecraft.getInstance());
+        PostChainManager.onScreenResize(Minecraft.getInstance());
     }
 
     @SubscribeEvent
     public static void onRenderStage(RenderLevelStageEvent event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+        if (!PostChainManager.shouldHandleStage(event.getStage())) {
             return;
         }
 
@@ -150,26 +64,31 @@ public final class ClientEvents {
             return;
         }
 
-        resizeChain(minecraft);
+        PostChainManager.prepareFrame(minecraft);
 
         float timeSeconds = strikeActive
-                ? state.getStrikeSeconds(event.getPartialTick())
-                : state.getChargeSeconds(event.getPartialTick());
+            ? state.getStrikeSeconds(event.getPartialTick())
+            : state.getChargeSeconds(event.getPartialTick());
 
         Matrix4f projection = new Matrix4f(event.getProjectionMatrix());
         Matrix4f inverseProjection = new Matrix4f(projection).invert();
         Matrix4f modelView = new Matrix4f(event.getPoseStack().last().pose());
         Vec3 cameraPos = event.getCamera().getPosition();
 
-        Vec3 targetPos = strikeActive ? state.getStrikePos() : state.getHitPos();
-        float distance = strikeActive
-                ? (float) cameraPos.distanceTo(state.getStrikePos())
-                : state.getHitDistance();
+        Vec3 strikePos = state.getStrikePos();
+        Vec3 hitPos = state.getHitPos();
+        Vec3 targetPos = strikeActive ? strikePos : hitPos;
+        if (targetPos == null) {
+            targetPos = cameraPos;
+        }
+
+        float distance = strikeActive && strikePos != null
+            ? (float) cameraPos.distanceTo(strikePos)
+            : state.getHitDistance();
         float isBlockHit = state.getHitKind() != RailgunState.HitKind.NONE ? 1.0F : 0.0F;
 
-        applyUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds, isBlockHit, strikeActive, state);
-
-        railgunChain.process(event.getPartialTick());
+        PostChainManager.render(event, modelView, projection, inverseProjection, cameraPos, targetPos, distance,
+            timeSeconds, isBlockHit, strikeActive, state);
     }
 
     @SubscribeEvent
@@ -178,6 +97,8 @@ public final class ClientEvents {
             return;
         }
         Minecraft minecraft = Minecraft.getInstance();
+        PostChainManager.tick(minecraft);
+
         RailgunState state = RailgunState.getInstance();
         state.tick(minecraft);
 
@@ -197,6 +118,10 @@ public final class ClientEvents {
         if (!(hitResult instanceof BlockHitResult blockHitResult)) {
             return;
         }
+        if (state.getStrikePos() == null) {
+            return;
+        }
+
         BlockPos target = blockHitResult.getBlockPos();
         OrbitalRailgunItem item = state.getActiveRailgunItem();
         if (item == null) {
@@ -215,142 +140,5 @@ public final class ClientEvents {
             double baseFov = Minecraft.getInstance().options.fov().get();
             event.setFOV(baseFov);
         }
-    }
-
-    private static void applyUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos, Vec3 targetPos,
-                                      float distance, float timeSeconds, float isBlockHit, boolean strikeActive, RailgunState state) {
-        List<PostPass> passes = getPasses();
-        if (passes.isEmpty()) {
-            return;
-        }
-
-        Minecraft minecraft = Minecraft.getInstance();
-        RenderTarget renderTarget = minecraft.getMainRenderTarget();
-        if (renderTarget == null) {
-            return;
-        }
-
-        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
-        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
-
-        for (PostPass pass : passes) {
-            EffectInstance effect = pass.getEffect();
-            if (effect == null) {
-                continue;
-            }
-
-            ResourceLocation passName = getPassName(pass);
-            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
-
-            setMatrix(effect, "ProjMat", projection);
-            if (expectsModelViewMatrix) {
-                setMatrix(effect, "ModelViewMat", modelView);
-            }
-            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
-            setVec3(effect, "CameraPosition", cameraPos);
-            setVec3(effect, "BlockPosition", targetPos);
-            setVec3(effect, "HitPos", targetPos);
-            setVec2(effect, "OutSize", width, height);
-            setFloat(effect, "iTime", timeSeconds);
-            setFloat(effect, "Distance", distance);
-            setFloat(effect, "IsBlockHit", isBlockHit);
-            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
-            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
-            setInt(effect, "HitKind", state.getHitKind().ordinal());
-        }
-    }
-
-    private static ResourceLocation getPassName(PostPass pass) {
-        String name = pass.getName();
-        return name != null ? ResourceLocation.tryParse(name) : null;
-    }
-
-    private static List<PostPass> getPasses() {
-        if (railgunChain == null) {
-            return Collections.emptyList();
-        }
-        if (PASSES_FIELD == null) {
-            return Collections.emptyList();
-        }
-        try {
-            Object value = PASSES_FIELD.get(railgunChain);
-            if (value instanceof List<?> list) {
-                @SuppressWarnings("unchecked")
-                List<PostPass> passes = (List<PostPass>) list;
-                return passes;
-            }
-            ForgeOrbitalRailgunMod.LOGGER.error(
-                    "Orbital railgun post chain passes had unexpected type: {}",
-                    value == null ? "null" : value.getClass().getName()
-            );
-        } catch (IllegalAccessException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
-            return Collections.emptyList();
-        }
-        return Collections.emptyList();
-    }
-
-    private static Field findPassesField() {
-        try {
-            return ObfuscationReflectionHelper.findField(PostChain.class, "passes");
-        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
-            try {
-                return ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
-            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
-                ForgeOrbitalRailgunMod.LOGGER.error(
-                        "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
-                        exception
-                );
-                return null;
-            }
-        }
-    }
-
-    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(matrix);
-        }
-    }
-
-    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
-        }
-    }
-
-    private static void setVec2(EffectInstance effect, String name, float x, float y) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(x, y);
-        }
-    }
-
-    private static void setFloat(EffectInstance effect, String name, float value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void setInt(EffectInstance effect, String name, int value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void closeChain() {
-        if (railgunChain != null) {
-            try {
-                railgunChain.close();
-            } catch (Exception ignored) {
-            }
-            railgunChain = null;
-        }
-        chainReady = false;
-        chainWidth = -1;
-        chainHeight = -1;
     }
 }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
@@ -1,0 +1,65 @@
+package net.tysontheember.orbitalrailgun.client;
+
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.minecraftforge.fml.ModList;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class ShaderModBridge {
+    private static final boolean IRIS_LOADED = ModList.get().isLoaded("iris");
+    private static final boolean OCULUS_LOADED = ModList.get().isLoaded("oculus");
+    private static final boolean SHADER_MOD_PRESENT = IRIS_LOADED || OCULUS_LOADED;
+
+    private static boolean reflectionInitialized;
+    private static Method shaderPackInUseMethod;
+    private static Object irisApiInstance;
+
+    private ShaderModBridge() {}
+
+    public static boolean isShaderModPresent() {
+        return SHADER_MOD_PRESENT;
+    }
+
+    public static boolean isShaderPackInUse() {
+        if (!SHADER_MOD_PRESENT) {
+            return false;
+        }
+        ensureReflection();
+        if (shaderPackInUseMethod == null || irisApiInstance == null) {
+            return false;
+        }
+        try {
+            Object result = shaderPackInUseMethod.invoke(irisApiInstance);
+            return result instanceof Boolean bool && bool;
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.debug("Failed to query Iris shader pack state", exception);
+            return false;
+        }
+    }
+
+    public static void reset() {
+        reflectionInitialized = false;
+        shaderPackInUseMethod = null;
+        irisApiInstance = null;
+    }
+
+    private static void ensureReflection() {
+        if (reflectionInitialized) {
+            return;
+        }
+        reflectionInitialized = true;
+        try {
+            Class<?> irisApiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            Method getInstance = irisApiClass.getMethod("getInstance");
+            Method isShaderPackInUse = irisApiClass.getMethod("isShaderPackInUse");
+            Object instance = getInstance.invoke(null);
+            if (instance != null) {
+                irisApiInstance = instance;
+                shaderPackInUseMethod = isShaderPackInUse;
+            }
+        } catch (ReflectiveOperationException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.debug("Iris API unavailable while checking shader pack state", exception);
+        }
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
@@ -1,0 +1,454 @@
+package net.tysontheember.orbitalrailgun.client.railgun;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.shaders.Uniform;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EffectInstance;
+import net.minecraft.client.renderer.PostChain;
+import net.minecraft.client.renderer.PostPass;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.ShaderModBridge;
+import net.tysontheember.orbitalrailgun.client.railgun.RailgunState;
+import net.tysontheember.orbitalrailgun.config.OrbitalRailgunConfig;
+import org.joml.Matrix4f;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public final class PostChainManager {
+    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
+    private static final ResourceLocation COMPAT_OVERLAY_ID = ForgeOrbitalRailgunMod.id("shaders/post/compat_overlay.json");
+    private static final RenderLevelStageEvent.Stage VANILLA_STAGE = RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS;
+    private static final RenderLevelStageEvent.Stage COMPAT_STAGE = RenderLevelStageEvent.Stage.AFTER_PARTICLES;
+    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
+        ForgeOrbitalRailgunMod.id("strike"),
+        ForgeOrbitalRailgunMod.id("gui")
+    );
+    private static final Field PASSES_FIELD = findPassesField();
+
+    private static Mode mode = Mode.DISABLED;
+    private static PostChain railgunChain;
+    private static EffectInstance compatOverlay;
+    private static int chainWidth = -1;
+    private static int chainHeight = -1;
+    private static boolean shaderPackActive;
+    private static boolean resourcesReady;
+    private static boolean loggedShaderPack;
+    private static ResourceManager lastResourceManager;
+
+    private PostChainManager() {}
+
+    public static void registerReloadListener(RegisterClientReloadListenersEvent event) {
+        event.registerReloadListener(new SimplePreparableReloadListener<Void>() {
+            @Override
+            protected Void prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
+                return null;
+            }
+
+            @Override
+            protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
+                reload(resourceManager);
+            }
+        });
+    }
+
+    public static void tick(Minecraft minecraft) {
+        if (minecraft == null) {
+            return;
+        }
+        boolean active = ShaderModBridge.isShaderPackInUse();
+        if (active != shaderPackActive) {
+            shaderPackActive = active;
+            loggedShaderPack = false;
+            updateMode(false);
+        }
+        if (mode == Mode.POST_CHAIN) {
+            resizeChain(minecraft);
+        }
+    }
+
+    public static void onScreenResize(Minecraft minecraft) {
+        if (mode == Mode.POST_CHAIN) {
+            resizeChain(minecraft);
+        }
+    }
+
+    public static boolean shouldHandleStage(RenderLevelStageEvent.Stage stage) {
+        if (!isActive()) {
+            return false;
+        }
+        RenderLevelStageEvent.Stage expected = mode == Mode.COMPAT_OVERLAY ? COMPAT_STAGE : VANILLA_STAGE;
+        return stage == expected;
+    }
+
+    public static boolean isActive() {
+        return resourcesReady && mode != Mode.DISABLED;
+    }
+
+    public static void prepareFrame(Minecraft minecraft) {
+        if (mode == Mode.POST_CHAIN) {
+            resizeChain(minecraft);
+        }
+    }
+
+    public static void render(RenderLevelStageEvent event, Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection,
+                               Vec3 cameraPos, Vec3 targetPos, float distance, float timeSeconds, float isBlockHit,
+                               boolean strikeActive, RailgunState state) {
+        if (!isActive()) {
+            return;
+        }
+
+        Vec3 safeTarget = targetPos != null ? targetPos : cameraPos;
+        float clampedTime = Math.max(timeSeconds, 0.0F);
+        float clampedDistance = Math.max(distance, 0.0F);
+        float strikeFlag = strikeActive ? 1.0F : 0.0F;
+        float selectionFlag = state.isCharging() ? 1.0F : 0.0F;
+        int hitKind = state.getHitKind().ordinal();
+
+        if (mode == Mode.POST_CHAIN) {
+            applyUniformsToChain(modelView, projection, inverseProjection, cameraPos, safeTarget, clampedDistance,
+                clampedTime, isBlockHit, strikeFlag, selectionFlag, hitKind);
+            if (railgunChain != null) {
+                railgunChain.process(event.getPartialTick());
+            }
+        } else if (mode == Mode.COMPAT_OVERLAY) {
+            applyUniformsToCompat(modelView, projection, inverseProjection, cameraPos, safeTarget, clampedDistance,
+                clampedTime, isBlockHit, strikeFlag, selectionFlag, hitKind);
+            renderCompatOverlay();
+        }
+    }
+
+    private static void reload(ResourceManager resourceManager) {
+        lastResourceManager = resourceManager;
+        ShaderModBridge.reset();
+        shaderPackActive = ShaderModBridge.isShaderPackInUse();
+        loggedShaderPack = false;
+        updateMode(true);
+    }
+
+    private static void updateMode(boolean forceReload) {
+        Mode desiredMode = computeDesiredMode();
+        if (!forceReload && desiredMode == mode) {
+            return;
+        }
+        closeResources();
+        mode = desiredMode;
+        resourcesReady = false;
+
+        if (mode == Mode.POST_CHAIN) {
+            loadPostChain();
+        } else if (mode == Mode.COMPAT_OVERLAY) {
+            loadCompatOverlay();
+        }
+    }
+
+    private static Mode computeDesiredMode() {
+        boolean forceVanilla = OrbitalRailgunConfig.CLIENT.forceVanillaPostChain.get();
+        boolean disableWithShaderpack = OrbitalRailgunConfig.CLIENT.disableWithShaderpack.get();
+        if (shaderPackActive && !forceVanilla) {
+            if (disableWithShaderpack) {
+                return Mode.DISABLED;
+            }
+            return Mode.COMPAT_OVERLAY;
+        }
+        return Mode.POST_CHAIN;
+    }
+
+    private static void loadPostChain() {
+        if (lastResourceManager == null) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+        try {
+            railgunChain = new PostChain(minecraft.getTextureManager(), lastResourceManager, mainTarget, RAILGUN_CHAIN_ID);
+            chainWidth = -1;
+            chainHeight = -1;
+            resizeChain(minecraft);
+            resourcesReady = railgunChain != null;
+        } catch (IOException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
+            closeChain();
+            resourcesReady = false;
+        }
+    }
+
+    private static void loadCompatOverlay() {
+        try {
+            compatOverlay = new EffectInstance(COMPAT_OVERLAY_ID);
+            resourcesReady = compatOverlay != null;
+            logCompatibility();
+        } catch (Exception exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun compatibility overlay", exception);
+            closeCompatOverlay();
+            resourcesReady = false;
+        }
+    }
+
+    private static void renderCompatOverlay() {
+        if (compatOverlay == null) {
+            return;
+        }
+        RenderTarget target = RenderSystem.getMainRenderTarget();
+        if (target == null) {
+            return;
+        }
+
+        RenderSystem.bindTexture(0);
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
+
+        RenderSystem.setShader(() -> compatOverlay);
+        compatOverlay.apply();
+
+        BufferBuilder bufferBuilder = Tesselator.getInstance().getBuilder();
+        bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION);
+        bufferBuilder.vertex(-1.0D, -1.0D, 0.0D).endVertex();
+        bufferBuilder.vertex(1.0D, -1.0D, 0.0D).endVertex();
+        bufferBuilder.vertex(1.0D, 1.0D, 0.0D).endVertex();
+        bufferBuilder.vertex(-1.0D, 1.0D, 0.0D).endVertex();
+        BufferUploader.drawWithShader(bufferBuilder.end());
+
+        compatOverlay.clear();
+
+        RenderSystem.depthMask(true);
+        RenderSystem.enableDepthTest();
+        RenderSystem.disableBlend();
+    }
+
+    private static void applyUniformsToChain(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos,
+                                             Vec3 targetPos, float distance, float timeSeconds, float isBlockHit,
+                                             float strikeFlag, float selectionFlag, int hitKind) {
+        List<PostPass> passes = getPasses();
+        if (passes.isEmpty()) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        RenderTarget renderTarget = minecraft.getMainRenderTarget();
+        if (renderTarget == null) {
+            return;
+        }
+        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
+        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
+        for (PostPass pass : passes) {
+            EffectInstance effect = pass.getEffect();
+            if (effect == null) {
+                continue;
+            }
+            ResourceLocation passName = getPassName(pass);
+            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
+            setMatrix(effect, "ProjMat", projection);
+            if (expectsModelViewMatrix) {
+                setMatrix(effect, "ModelViewMat", modelView);
+            }
+            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
+            setVec3(effect, "CameraPosition", cameraPos);
+            setVec3(effect, "BlockPosition", targetPos);
+            setVec3(effect, "HitPos", targetPos);
+            setVec2(effect, "OutSize", width, height);
+            setFloat(effect, "iTime", timeSeconds);
+            setFloat(effect, "Distance", distance);
+            setFloat(effect, "IsBlockHit", isBlockHit);
+            setFloat(effect, "StrikeActive", strikeFlag);
+            setFloat(effect, "SelectionActive", selectionFlag);
+            setInt(effect, "HitKind", hitKind);
+        }
+    }
+
+    private static void applyUniformsToCompat(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos,
+                                              Vec3 targetPos, float distance, float timeSeconds, float isBlockHit,
+                                              float strikeFlag, float selectionFlag, int hitKind) {
+        if (compatOverlay == null) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        RenderTarget renderTarget = minecraft.getMainRenderTarget();
+        if (renderTarget == null) {
+            return;
+        }
+        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
+        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
+        setMatrix(compatOverlay, "ProjMat", projection);
+        setMatrix(compatOverlay, "ModelViewMat", modelView);
+        setMatrix(compatOverlay, "InverseTransformMatrix", inverseProjection);
+        setVec3(compatOverlay, "CameraPosition", cameraPos);
+        setVec3(compatOverlay, "BlockPosition", targetPos);
+        setVec3(compatOverlay, "HitPos", targetPos);
+        setVec2(compatOverlay, "OutSize", width, height);
+        setFloat(compatOverlay, "iTime", timeSeconds);
+        setFloat(compatOverlay, "Distance", distance);
+        setFloat(compatOverlay, "IsBlockHit", isBlockHit);
+        setFloat(compatOverlay, "StrikeActive", strikeFlag);
+        setFloat(compatOverlay, "SelectionActive", selectionFlag);
+        setInt(compatOverlay, "HitKind", hitKind);
+    }
+
+    private static void resizeChain(Minecraft minecraft) {
+        if (railgunChain == null) {
+            return;
+        }
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+        int width = mainTarget.width;
+        int height = mainTarget.height;
+        if (width == chainWidth && height == chainHeight) {
+            return;
+        }
+        railgunChain.resize(width, height);
+        chainWidth = width;
+        chainHeight = height;
+    }
+
+    private static void closeResources() {
+        closeChain();
+        closeCompatOverlay();
+    }
+
+    private static void closeChain() {
+        if (railgunChain != null) {
+            try {
+                railgunChain.close();
+            } catch (Exception ignored) {
+            }
+            railgunChain = null;
+        }
+        chainWidth = -1;
+        chainHeight = -1;
+    }
+
+    private static void closeCompatOverlay() {
+        if (compatOverlay != null) {
+            try {
+                compatOverlay.close();
+            } catch (Exception ignored) {
+            }
+            compatOverlay = null;
+        }
+    }
+
+    private static List<PostPass> getPasses() {
+        if (railgunChain == null) {
+            return Collections.emptyList();
+        }
+        if (PASSES_FIELD == null) {
+            return Collections.emptyList();
+        }
+        try {
+            Object value = PASSES_FIELD.get(railgunChain);
+            if (value instanceof List<?> list) {
+                @SuppressWarnings("unchecked")
+                List<PostPass> passes = (List<PostPass>) list;
+                return passes;
+            }
+            ForgeOrbitalRailgunMod.LOGGER.error("Orbital railgun post chain passes had unexpected type: {}",
+                value == null ? "null" : value.getClass().getName());
+        } catch (IllegalAccessException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
+            return Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+
+    private static ResourceLocation getPassName(PostPass pass) {
+        String name = pass.getName();
+        return name != null ? ResourceLocation.tryParse(name) : null;
+    }
+
+    private static Field findPassesField() {
+        try {
+            Field field = PostChain.class.getDeclaredField("passes");
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException ignored) {
+            try {
+                Field field = PostChain.class.getDeclaredField("f_110009_");
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.error(
+                    "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
+                    exception
+                );
+                return null;
+            }
+        }
+    }
+
+    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(matrix);
+        }
+    }
+
+    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
+        }
+    }
+
+    private static void setVec2(EffectInstance effect, String name, float x, float y) {
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(x, y);
+        }
+    }
+
+    private static void setFloat(EffectInstance effect, String name, float value) {
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(value);
+        }
+    }
+
+    private static void setInt(EffectInstance effect, String name, int value) {
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(value);
+        }
+    }
+
+    private static void logCompatibility() {
+        if (!OrbitalRailgunConfig.CLIENT.logIrisState.get()) {
+            return;
+        }
+        if (!shaderPackActive) {
+            return;
+        }
+        if (loggedShaderPack) {
+            return;
+        }
+        ForgeOrbitalRailgunMod.LOGGER.info("[orbital_railgun] Shader pack detected: enabling compatibility mode");
+        loggedShaderPack = true;
+    }
+
+    private enum Mode {
+        DISABLED,
+        POST_CHAIN,
+        COMPAT_OVERLAY
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunConfig.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunConfig.java
@@ -6,11 +6,17 @@ import org.apache.commons.lang3.tuple.Pair;
 public final class OrbitalRailgunConfig {
     public static final ForgeConfigSpec COMMON_SPEC;
     public static final Common COMMON;
+    public static final ForgeConfigSpec CLIENT_SPEC;
+    public static final Client CLIENT;
 
     static {
-        Pair<Common, ForgeConfigSpec> pair = new ForgeConfigSpec.Builder().configure(Common::new);
-        COMMON_SPEC = pair.getRight();
-        COMMON = pair.getLeft();
+        Pair<Common, ForgeConfigSpec> commonPair = new ForgeConfigSpec.Builder().configure(Common::new);
+        COMMON_SPEC = commonPair.getRight();
+        COMMON = commonPair.getLeft();
+
+        Pair<Client, ForgeConfigSpec> clientPair = new ForgeConfigSpec.Builder().configure(Client::new);
+        CLIENT_SPEC = clientPair.getRight();
+        CLIENT = clientPair.getLeft();
     }
 
     private OrbitalRailgunConfig() {}
@@ -31,6 +37,26 @@ public final class OrbitalRailgunConfig {
             suckEntities = builder
                 .comment("Whether entities are pulled towards the strike before detonation.")
                 .define("suckEntities", true);
+            builder.pop();
+        }
+    }
+
+    public static final class Client {
+        public final ForgeConfigSpec.BooleanValue disableWithShaderpack;
+        public final ForgeConfigSpec.BooleanValue logIrisState;
+        public final ForgeConfigSpec.BooleanValue forceVanillaPostChain;
+
+        private Client(ForgeConfigSpec.Builder builder) {
+            builder.push("compat");
+            disableWithShaderpack = builder
+                .comment("Disable orbital railgun overlays when a shader pack is active.")
+                .define("disableWithShaderpack", false);
+            logIrisState = builder
+                .comment("Log shader pack compatibility status when resources reload.")
+                .define("logIrisState", true);
+            forceVanillaPostChain = builder
+                .comment("Force the vanilla orbital railgun post chain even when a shader pack is active.")
+                .define("forceVanillaPostChain", false);
             builder.pop();
         }
     }

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.fsh
@@ -1,0 +1,50 @@
+#version 330 compatibility
+
+uniform float iTime;
+uniform float StrikeActive;
+uniform float SelectionActive;
+uniform float Distance;
+uniform float IsBlockHit;
+uniform int HitKind;
+uniform vec2 OutSize;
+
+in vec2 vUv;
+
+out vec4 fragColor;
+
+void main() {
+    vec2 size = vec2(max(OutSize.x, 1.0), max(OutSize.y, 1.0));
+    vec2 aspect = vec2(size.x / size.y, 1.0);
+    vec2 centered = (vUv * 2.0 - 1.0) * aspect;
+    float radius = length(centered);
+
+    float strikeMix = clamp(StrikeActive, 0.0, 1.0);
+    float chargeMix = clamp(SelectionActive, 0.0, 1.0);
+    float active = max(strikeMix, chargeMix);
+    float pulse = 0.5 + 0.5 * sin(iTime * 4.0);
+
+    vec3 strikeColor = vec3(1.0, 0.36, 0.10);
+    vec3 chargeColor = vec3(0.25, 0.70, 1.00);
+    vec3 color = mix(chargeColor, strikeColor, strikeMix);
+
+    float vignette = pow(clamp(1.0 - radius, 0.0, 1.0), 2.0);
+    float cross = exp(-32.0 * dot(centered, centered));
+    float distanceFade = clamp(1.0 - Distance / 128.0, 0.0, 1.0);
+
+    float alpha = active * vignette * (0.35 + 0.35 * pulse);
+    alpha *= mix(1.0, distanceFade, strikeMix);
+    alpha += cross * (0.2 + 0.25 * strikeMix);
+
+    if (IsBlockHit > 0.5) {
+        float flash = 0.25 + 0.35 * pulse;
+        color = mix(color, vec3(1.0, 0.9, 0.5), 0.5);
+        alpha += flash;
+    }
+
+    if (HitKind > 0) {
+        alpha += 0.1;
+    }
+
+    alpha = clamp(alpha, 0.0, 1.0);
+    fragColor = vec4(color * (0.7 + 0.3 * pulse), alpha);
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
@@ -1,0 +1,26 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "orbital_railgun:post/compat_overlay",
+  "fragment": "orbital_railgun:post/compat_overlay",
+  "attributes": [ "Position" ],
+  "samplers": [ ],
+  "uniforms": [
+    { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "InverseTransformMatrix", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize", "type": "float", "count": 2, "values": [ 1.0, 1.0 ] },
+    { "name": "CameraPosition", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+    { "name": "BlockPosition", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+    { "name": "HitPos", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+    { "name": "iTime", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "Distance", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "IsBlockHit", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "StrikeActive", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "SelectionActive", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "HitKind", "type": "int", "count": 1, "values": [ 0 ] }
+  ]
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.vsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.vsh
@@ -1,0 +1,9 @@
+#version 330 compatibility
+
+in vec3 Position;
+out vec2 vUv;
+
+void main() {
+    vUv = (Position.xy + 1.0) * 0.5;
+    gl_Position = vec4(Position, 1.0);
+}


### PR DESCRIPTION
## Summary
- add a shader mod bridge and compatibility-aware post chain manager so the railgun overlays render after Iris/Oculus composite stages
- provide client config toggles and fallback shaders that draw the weapon overlay without allocating extra framebuffers
- refactor client events to rely on the new manager and shader files for consistent rendering across shader pack toggles

## Testing
- ⚠️ `./gradlew build` *(fails: gradlew wrapper script is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e1920a251c83259a4035d35b93ed33