### PR TITLE
Add shader-pack compatibility overlay for orbital railgun

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
@@ -1,5 +1,6 @@
 package net.tysontheember.orbitalrailgun;
 
+import net.tysontheember.orbitalrailgun.config.OrbitalRailgunClientConfig;
 import net.tysontheember.orbitalrailgun.config.OrbitalRailgunConfig;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.Network;
@@ -37,6 +38,7 @@ public class ForgeOrbitalRailgunMod {
         modBus.addListener(this::onCommonSetup);
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, OrbitalRailgunConfig.COMMON_SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, OrbitalRailgunClientConfig.CLIENT_SPEC);
 
         OrbitalRailgunStrikeManager.register();
     }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -1,19 +1,14 @@
 package net.tysontheember.orbitalrailgun.client;
 
-import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
 import net.tysontheember.orbitalrailgun.client.railgun.RailgunState;
+import net.tysontheember.orbitalrailgun.client.railgun.PostChainManager;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.C2S_RequestFire;
 import net.tysontheember.orbitalrailgun.network.Network;
-import com.mojang.blaze3d.shaders.Uniform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.EffectInstance;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.client.renderer.PostPass;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
@@ -25,44 +20,21 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
-import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.event.ViewportEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import org.joml.Matrix4f;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = ForgeOrbitalRailgunMod.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ClientEvents {
-    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
-    private static final Field PASSES_FIELD = findPassesField();
-    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
-            ForgeOrbitalRailgunMod.id("strike"),
-            ForgeOrbitalRailgunMod.id("gui")
-    );
-
-    private static PostChain railgunChain;
-    private static boolean chainReady;
-    private static int chainWidth = -1;
-    private static int chainHeight = -1;
+    private static final RenderLevelStageEvent.Stage RENDER_STAGE = RenderLevelStageEvent.Stage.AFTER_WEATHER;
 
     private static boolean attackWasDown;
 
     static {
-        if (PASSES_FIELD != null) {
-            PASSES_FIELD.setAccessible(true);
-        } else {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to locate orbital railgun post chain passes field");
-        }
         FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEvents::onRegisterReloadListeners);
     }
 
@@ -77,67 +49,20 @@ public final class ClientEvents {
 
             @Override
             protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
-                ClientEvents.reloadChain(resourceManager);
+                PostChainManager.reload(resourceManager);
             }
         });    }
 
-    private static void reloadChain(ResourceManager resourceManager) {
-        Minecraft minecraft = Minecraft.getInstance();
-        closeChain();
-        if (minecraft.getMainRenderTarget() == null) {
-            chainReady = false;
-            return;
-        }
-
-        try {
-            railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, minecraft.getMainRenderTarget(), RAILGUN_CHAIN_ID);
-            chainReady = true;
-            chainWidth = -1;
-            chainHeight = -1;
-            resizeChain(minecraft);
-        } catch (IOException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
-            chainReady = false;
-            closeChain();
-        }
-    }
-
-    private static void resizeChain(Minecraft minecraft) {
-        if (railgunChain == null) {
-            return;
-        }
-        RenderTarget mainTarget = minecraft.getMainRenderTarget();
-        if (mainTarget == null) {
-            return;
-        }
-        int width = mainTarget.width;
-        int height = mainTarget.height;
-        if (width == chainWidth && height == chainHeight) {
-            return;
-        }
-        railgunChain.resize(width, height);
-        chainWidth = width;
-        chainHeight = height;
-    }
-
-    @SubscribeEvent
-    public static void onScreenRender(ScreenEvent.Render.Post event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        resizeChain(Minecraft.getInstance());
-    }
-
     @SubscribeEvent
     public static void onRenderStage(RenderLevelStageEvent event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+        if (event.getStage() != RENDER_STAGE) {
             return;
         }
 
         Minecraft minecraft = Minecraft.getInstance();
+        if (!PostChainManager.prepareFrame(minecraft)) {
+            return;
+        }
         if (minecraft.level == null) {
             return;
         }
@@ -149,8 +74,6 @@ public final class ClientEvents {
         if (!strikeActive && !chargeActive) {
             return;
         }
-
-        resizeChain(minecraft);
 
         float timeSeconds = strikeActive
                 ? state.getStrikeSeconds(event.getPartialTick())
@@ -167,9 +90,8 @@ public final class ClientEvents {
                 : state.getHitDistance();
         float isBlockHit = state.getHitKind() != RailgunState.HitKind.NONE ? 1.0F : 0.0F;
 
-        applyUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds, isBlockHit, strikeActive, state);
-
-        railgunChain.process(event.getPartialTick());
+        PostChainManager.render(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds,
+                isBlockHit, strikeActive, state, event.getPartialTick());
     }
 
     @SubscribeEvent
@@ -217,140 +139,4 @@ public final class ClientEvents {
         }
     }
 
-    private static void applyUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos, Vec3 targetPos,
-                                      float distance, float timeSeconds, float isBlockHit, boolean strikeActive, RailgunState state) {
-        List<PostPass> passes = getPasses();
-        if (passes.isEmpty()) {
-            return;
-        }
-
-        Minecraft minecraft = Minecraft.getInstance();
-        RenderTarget renderTarget = minecraft.getMainRenderTarget();
-        if (renderTarget == null) {
-            return;
-        }
-
-        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
-        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
-
-        for (PostPass pass : passes) {
-            EffectInstance effect = pass.getEffect();
-            if (effect == null) {
-                continue;
-            }
-
-            ResourceLocation passName = getPassName(pass);
-            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
-
-            setMatrix(effect, "ProjMat", projection);
-            if (expectsModelViewMatrix) {
-                setMatrix(effect, "ModelViewMat", modelView);
-            }
-            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
-            setVec3(effect, "CameraPosition", cameraPos);
-            setVec3(effect, "BlockPosition", targetPos);
-            setVec3(effect, "HitPos", targetPos);
-            setVec2(effect, "OutSize", width, height);
-            setFloat(effect, "iTime", timeSeconds);
-            setFloat(effect, "Distance", distance);
-            setFloat(effect, "IsBlockHit", isBlockHit);
-            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
-            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
-            setInt(effect, "HitKind", state.getHitKind().ordinal());
-        }
-    }
-
-    private static ResourceLocation getPassName(PostPass pass) {
-        String name = pass.getName();
-        return name != null ? ResourceLocation.tryParse(name) : null;
-    }
-
-    private static List<PostPass> getPasses() {
-        if (railgunChain == null) {
-            return Collections.emptyList();
-        }
-        if (PASSES_FIELD == null) {
-            return Collections.emptyList();
-        }
-        try {
-            Object value = PASSES_FIELD.get(railgunChain);
-            if (value instanceof List<?> list) {
-                @SuppressWarnings("unchecked")
-                List<PostPass> passes = (List<PostPass>) list;
-                return passes;
-            }
-            ForgeOrbitalRailgunMod.LOGGER.error(
-                    "Orbital railgun post chain passes had unexpected type: {}",
-                    value == null ? "null" : value.getClass().getName()
-            );
-        } catch (IllegalAccessException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
-            return Collections.emptyList();
-        }
-        return Collections.emptyList();
-    }
-
-    private static Field findPassesField() {
-        try {
-            return ObfuscationReflectionHelper.findField(PostChain.class, "passes");
-        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
-            try {
-                return ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
-            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
-                ForgeOrbitalRailgunMod.LOGGER.error(
-                        "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
-                        exception
-                );
-                return null;
-            }
-        }
-    }
-
-    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(matrix);
-        }
-    }
-
-    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
-        }
-    }
-
-    private static void setVec2(EffectInstance effect, String name, float x, float y) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(x, y);
-        }
-    }
-
-    private static void setFloat(EffectInstance effect, String name, float value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void setInt(EffectInstance effect, String name, int value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void closeChain() {
-        if (railgunChain != null) {
-            try {
-                railgunChain.close();
-            } catch (Exception ignored) {
-            }
-            railgunChain = null;
-        }
-        chainReady = false;
-        chainWidth = -1;
-        chainHeight = -1;
-    }
 }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
@@ -1,0 +1,63 @@
+package net.tysontheember.orbitalrailgun.client;
+
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.minecraftforge.fml.ModList;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public final class ShaderModBridge {
+    private static final boolean IRIS_LOADED = ModList.get().isLoaded("iris");
+    private static final boolean OCULUS_LOADED = ModList.get().isLoaded("oculus");
+
+    private static final Method IRIS_GET_INSTANCE;
+    private static final Method IRIS_IS_SHADER_PACK_IN_USE;
+
+    static {
+        Method getInstance = null;
+        Method isShaderPackInUse = null;
+        if (isShaderModPresent()) {
+            try {
+                Class<?> irisApiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+                getInstance = irisApiClass.getMethod("getInstance");
+                isShaderPackInUse = irisApiClass.getMethod("isShaderPackInUse");
+            } catch (ClassNotFoundException | NoSuchMethodException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.debug("Unable to resolve Iris API for shader detection", exception);
+                getInstance = null;
+                isShaderPackInUse = null;
+            }
+        }
+        IRIS_GET_INSTANCE = getInstance;
+        IRIS_IS_SHADER_PACK_IN_USE = isShaderPackInUse;
+    }
+
+    private ShaderModBridge() {}
+
+    public static boolean isShaderModPresent() {
+        return IRIS_LOADED || OCULUS_LOADED;
+    }
+
+    public static boolean isShaderPackInUse() {
+        if (!isShaderModPresent()) {
+            return false;
+        }
+        if (IRIS_GET_INSTANCE == null || IRIS_IS_SHADER_PACK_IN_USE == null) {
+            return false;
+        }
+        try {
+            Object instance = IRIS_GET_INSTANCE.invoke(null);
+            if (instance instanceof Optional<?> optional) {
+                instance = optional.orElse(null);
+            }
+            if (instance == null) {
+                return false;
+            }
+            Object value = IRIS_IS_SHADER_PACK_IN_USE.invoke(instance);
+            return value instanceof Boolean bool ? bool : false;
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.debug("Failed to query Iris shader pack state", exception);
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
@@ -1,0 +1,455 @@
+package net.tysontheember.orbitalrailgun.client.railgun;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EffectInstance;
+import net.minecraft.client.renderer.PostChain;
+import net.minecraft.client.renderer.PostPass;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.ShaderModBridge;
+import net.tysontheember.orbitalrailgun.config.OrbitalRailgunClientConfig;
+
+import org.joml.Matrix4f;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public final class PostChainManager {
+    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
+    private static final ResourceLocation COMPAT_OVERLAY_ID = ForgeOrbitalRailgunMod.id("shaders/post/compat_overlay.json");
+    private static final Field PASSES_FIELD = findPassesField();
+    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
+        ForgeOrbitalRailgunMod.id("strike"),
+        ForgeOrbitalRailgunMod.id("gui")
+    );
+
+    private static PostChain railgunChain;
+    private static EffectInstance compatOverlay;
+    private static ResourceManager resourceManager;
+
+    private static boolean chainReady;
+    private static boolean overlayReady;
+    private static boolean compatibilityMode;
+    private static boolean shaderPackActive;
+    private static boolean shaderModPresent;
+    private static boolean renderSuppressed;
+    private static boolean loggedCompatMessage;
+
+    private static boolean disableWithShaderpack;
+    private static boolean logIrisState;
+    private static boolean forceVanillaPostChain;
+
+    private static int chainWidth = -1;
+    private static int chainHeight = -1;
+
+    private PostChainManager() {}
+
+    public static void reload(ResourceManager manager) {
+        resourceManager = manager;
+        disableWithShaderpack = OrbitalRailgunClientConfig.CLIENT.disableWithShaderpack.get();
+        logIrisState = OrbitalRailgunClientConfig.CLIENT.logIrisState.get();
+        forceVanillaPostChain = OrbitalRailgunClientConfig.CLIENT.forceVanillaPostChain.get();
+        shaderModPresent = ShaderModBridge.isShaderModPresent();
+        shaderPackActive = shaderModPresent && ShaderModBridge.isShaderPackInUse();
+        rebuildResources();
+    }
+
+    public static boolean prepareFrame(Minecraft minecraft) {
+        if (minecraft == null) {
+            return false;
+        }
+        updateShaderState();
+        if (renderSuppressed) {
+            return false;
+        }
+        if (compatibilityMode) {
+            return overlayReady && compatOverlay != null;
+        }
+        if (!chainReady || railgunChain == null) {
+            return false;
+        }
+        resizeChain(minecraft);
+        return chainReady;
+    }
+
+    public static void render(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos, Vec3 targetPos,
+                               float distance, float timeSeconds, float isBlockHit, boolean strikeActive, RailgunState state,
+                               float partialTick) {
+        if (renderSuppressed) {
+            return;
+        }
+        if (compatibilityMode) {
+            if (!overlayReady || compatOverlay == null) {
+                return;
+            }
+            applyOverlayUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds,
+                isBlockHit, strikeActive, state);
+            renderCompatOverlay();
+            return;
+        }
+
+        if (!chainReady || railgunChain == null) {
+            return;
+        }
+        applyPostChainUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds,
+            isBlockHit, strikeActive, state);
+        railgunChain.process(partialTick);
+    }
+
+    public static void close() {
+        closeChain();
+        closeOverlay();
+    }
+
+    private static void updateShaderState() {
+        if (!shaderModPresent) {
+            compatibilityMode = false;
+            renderSuppressed = false;
+            return;
+        }
+        boolean newState = ShaderModBridge.isShaderPackInUse();
+        if (newState != shaderPackActive) {
+            shaderPackActive = newState;
+            rebuildResources();
+        }
+    }
+
+    private static void rebuildResources() {
+        closeChain();
+        closeOverlay();
+        loggedCompatMessage = false;
+
+        renderSuppressed = shaderPackActive && disableWithShaderpack;
+        compatibilityMode = shaderPackActive && !forceVanillaPostChain && !renderSuppressed;
+
+        if (renderSuppressed) {
+            return;
+        }
+
+        if (compatibilityMode) {
+            loadCompatOverlay();
+            if (compatibilityMode && logIrisState) {
+                ForgeOrbitalRailgunMod.LOGGER.info("[{}] Shader pack detected: enabling compatibility mode", ForgeOrbitalRailgunMod.MOD_ID);
+                loggedCompatMessage = true;
+            }
+        } else {
+            loadPostChain();
+            if (!shaderPackActive) {
+                loggedCompatMessage = false;
+            } else if (logIrisState && !loggedCompatMessage) {
+                ForgeOrbitalRailgunMod.LOGGER.info("[{}] Shader pack detected but forcing vanilla post chain", ForgeOrbitalRailgunMod.MOD_ID);
+                loggedCompatMessage = true;
+            }
+        }
+    }
+
+    private static void loadPostChain() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft == null) {
+            return;
+        }
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+        if (resourceManager == null) {
+            resourceManager = minecraft.getResourceManager();
+        }
+        try {
+            railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, mainTarget, RAILGUN_CHAIN_ID);
+            chainReady = true;
+            chainWidth = -1;
+            chainHeight = -1;
+            resizeChain(minecraft);
+        } catch (IOException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
+            chainReady = false;
+            closeChain();
+        }
+    }
+
+    private static void loadCompatOverlay() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft == null) {
+            return;
+        }
+        ResourceManager manager = resourceManager != null ? resourceManager : minecraft.getResourceManager();
+        if (manager == null) {
+            return;
+        }
+        try {
+            compatOverlay = new EffectInstance(manager, COMPAT_OVERLAY_ID.toString());
+            overlayReady = true;
+        } catch (IOException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun compatibility overlay", exception);
+            overlayReady = false;
+            closeOverlay();
+        }
+    }
+
+    private static void resizeChain(Minecraft minecraft) {
+        if (railgunChain == null) {
+            return;
+        }
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+        int width = mainTarget.width;
+        int height = mainTarget.height;
+        if (width == chainWidth && height == chainHeight) {
+            return;
+        }
+        railgunChain.resize(width, height);
+        chainWidth = width;
+        chainHeight = height;
+    }
+
+    private static void applyPostChainUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection,
+                                               Vec3 cameraPos, Vec3 targetPos, float distance, float timeSeconds,
+                                               float isBlockHit, boolean strikeActive, RailgunState state) {
+        List<PostPass> passes = getPasses();
+        if (passes.isEmpty()) {
+            return;
+        }
+
+        RenderTarget renderTarget = Minecraft.getInstance().getMainRenderTarget();
+        if (renderTarget == null) {
+            return;
+        }
+
+        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
+        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
+
+        for (PostPass pass : passes) {
+            EffectInstance effect = pass.getEffect();
+            if (effect == null) {
+                continue;
+            }
+
+            ResourceLocation passName = getPassName(pass);
+            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
+
+            setMatrix(effect, "ProjMat", projection);
+            if (expectsModelViewMatrix) {
+                setMatrix(effect, "ModelViewMat", modelView);
+            }
+            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
+            setVec3(effect, "CameraPosition", cameraPos);
+            setVec3(effect, "BlockPosition", targetPos);
+            setVec3(effect, "HitPos", targetPos);
+            setVec2(effect, "OutSize", width, height);
+            setFloat(effect, "iTime", timeSeconds);
+            setFloat(effect, "Distance", distance);
+            setFloat(effect, "IsBlockHit", isBlockHit);
+            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
+            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
+            setInt(effect, "HitKind", state.getHitKind().ordinal());
+        }
+    }
+
+    private static void applyOverlayUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection,
+                                             Vec3 cameraPos, Vec3 targetPos, float distance, float timeSeconds,
+                                             float isBlockHit, boolean strikeActive, RailgunState state) {
+        if (compatOverlay == null) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft == null) {
+            return;
+        }
+        RenderTarget target = minecraft.getMainRenderTarget();
+        if (target == null) {
+            return;
+        }
+
+        float width = target.width > 0 ? target.width : target.viewWidth;
+        float height = target.height > 0 ? target.height : target.viewHeight;
+
+        float clampedTime = Math.max(0.0F, timeSeconds);
+        float clampedDistance = Mth.clamp(distance, 0.0F, 2048.0F);
+        float clampedIsBlockHit = Mth.clamp(isBlockHit, 0.0F, 1.0F);
+
+        setMatrix(compatOverlay, "ProjMat", projection);
+        setMatrix(compatOverlay, "ModelViewMat", modelView);
+        setMatrix(compatOverlay, "InverseTransformMatrix", inverseProjection);
+        setVec3(compatOverlay, "CameraPosition", cameraPos);
+        setVec3(compatOverlay, "BlockPosition", targetPos);
+        setVec3(compatOverlay, "HitPos", targetPos);
+        setVec2(compatOverlay, "OutSize", width, height);
+        setFloat(compatOverlay, "iTime", clampedTime);
+        setFloat(compatOverlay, "Distance", clampedDistance);
+        setFloat(compatOverlay, "IsBlockHit", clampedIsBlockHit);
+        setFloat(compatOverlay, "StrikeActive", strikeActive ? 1.0F : 0.0F);
+        setFloat(compatOverlay, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
+        setInt(compatOverlay, "HitKind", state.getHitKind().ordinal());
+    }
+
+    private static void renderCompatOverlay() {
+        if (compatOverlay == null) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft == null) {
+            return;
+        }
+        RenderTarget target = minecraft.getMainRenderTarget();
+        if (target == null) {
+            return;
+        }
+
+        RenderSystem.bindTexture(0);
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+
+        try {
+            compatOverlay.apply();
+
+            BufferBuilder builder = Tesselator.getInstance().getBuilder();
+            builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            builder.vertex(-1.0D, -1.0D, 0.0D).uv(0.0F, 0.0F).endVertex();
+            builder.vertex(1.0D, -1.0D, 0.0D).uv(1.0F, 0.0F).endVertex();
+            builder.vertex(1.0D, 1.0D, 0.0D).uv(1.0F, 1.0F).endVertex();
+            builder.vertex(-1.0D, 1.0D, 0.0D).uv(0.0F, 1.0F).endVertex();
+            BufferUploader.drawWithShader(builder.end());
+        } finally {
+            RenderSystem.disableBlend();
+            RenderSystem.depthMask(true);
+            RenderSystem.enableDepthTest();
+        }
+    }
+
+    private static void closeChain() {
+        if (railgunChain != null) {
+            try {
+                railgunChain.close();
+            } catch (Exception ignored) {
+            }
+            railgunChain = null;
+        }
+        chainReady = false;
+        chainWidth = -1;
+        chainHeight = -1;
+    }
+
+    private static void closeOverlay() {
+        if (compatOverlay != null) {
+            try {
+                compatOverlay.close();
+            } catch (Exception ignored) {
+            }
+            compatOverlay = null;
+        }
+        overlayReady = false;
+    }
+
+    private static List<PostPass> getPasses() {
+        if (railgunChain == null) {
+            return Collections.emptyList();
+        }
+        if (PASSES_FIELD == null) {
+            return Collections.emptyList();
+        }
+        try {
+            Object value = PASSES_FIELD.get(railgunChain);
+            if (value instanceof List<?> list) {
+                @SuppressWarnings("unchecked")
+                List<PostPass> passes = (List<PostPass>) list;
+                return passes;
+            }
+            ForgeOrbitalRailgunMod.LOGGER.error("Orbital railgun post chain passes had unexpected type: {}",
+                value == null ? "null" : value.getClass().getName());
+        } catch (IllegalAccessException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
+            return Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+
+    private static ResourceLocation getPassName(PostPass pass) {
+        String name = pass.getName();
+        return name != null ? ResourceLocation.tryParse(name) : null;
+    }
+
+    private static Field findPassesField() {
+        try {
+            return ObfuscationReflectionHelper.findField(PostChain.class, "passes");
+        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
+            try {
+                return ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
+            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.error(
+                    "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
+                    exception
+                );
+                return null;
+            }
+        }
+    }
+
+    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
+        if (effect == null) {
+            return;
+        }
+        var uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(matrix);
+        }
+    }
+
+    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
+        if (effect == null || vec == null) {
+            return;
+        }
+        var uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
+        }
+    }
+
+    private static void setVec2(EffectInstance effect, String name, float x, float y) {
+        if (effect == null) {
+            return;
+        }
+        var uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(x, y);
+        }
+    }
+
+    private static void setFloat(EffectInstance effect, String name, float value) {
+        if (effect == null) {
+            return;
+        }
+        var uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(value);
+        }
+    }
+
+    private static void setInt(EffectInstance effect, String name, int value) {
+        if (effect == null) {
+            return;
+        }
+        var uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(value);
+        }
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunClientConfig.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunClientConfig.java
@@ -1,0 +1,37 @@
+package net.tysontheember.orbitalrailgun.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+import org.apache.commons.lang3.tuple.Pair;
+
+public final class OrbitalRailgunClientConfig {
+    public static final ForgeConfigSpec CLIENT_SPEC;
+    public static final Client CLIENT;
+
+    static {
+        Pair<Client, ForgeConfigSpec> pair = new ForgeConfigSpec.Builder().configure(Client::new);
+        CLIENT = pair.getLeft();
+        CLIENT_SPEC = pair.getRight();
+    }
+
+    private OrbitalRailgunClientConfig() {}
+
+    public static final class Client {
+        public final ForgeConfigSpec.BooleanValue disableWithShaderpack;
+        public final ForgeConfigSpec.BooleanValue logIrisState;
+        public final ForgeConfigSpec.BooleanValue forceVanillaPostChain;
+
+        private Client(ForgeConfigSpec.Builder builder) {
+            builder.push("compat");
+            disableWithShaderpack = builder
+                .comment("Disable orbital railgun post effects entirely when a shader pack is active.")
+                .define("disableWithShaderpack", false);
+            logIrisState = builder
+                .comment("Log whether Iris/Oculus shader packs are detected during reloads.")
+                .define("logIrisState", true);
+            forceVanillaPostChain = builder
+                .comment("Always run the vanilla post-processing chain even when a shader pack is active.")
+                .define("forceVanillaPostChain", false);
+            builder.pop();
+        }
+    }
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.fsh
@@ -1,0 +1,45 @@
+#version 150
+
+uniform float iTime;
+uniform float StrikeActive;
+uniform float SelectionActive;
+uniform float Distance;
+uniform int HitKind;
+uniform vec2 OutSize;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+float saturate(float value) {
+    return clamp(value, 0.0, 1.0);
+}
+
+void main() {
+    float activity = saturate(StrikeActive + SelectionActive);
+    if (activity <= 0.0) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float aspect = OutSize.y > 0.0 ? OutSize.x / OutSize.y : 1.0;
+    vec2 centered = vec2((texCoord.x - 0.5) * aspect, texCoord.y - 0.5) * 2.0;
+    float radius = length(centered);
+    float vignette = 1.0 - smoothstep(0.45, 1.2, radius);
+    float cross = exp(-28.0 * min(centered.x * centered.x, centered.y * centered.y));
+    float distanceFade = saturate(1.0 - Distance / 512.0);
+    float pulse = 0.6 + 0.4 * sin(iTime * 4.0);
+
+    float strikeMix = saturate(StrikeActive);
+    float hitMix = HitKind > 0 ? 1.0 : 0.0;
+    vec3 chargeColor = vec3(0.25, 0.85, 1.05);
+    vec3 strikeColor = vec3(1.0, 0.62, 0.28);
+    vec3 hitColor = vec3(1.0, 0.38, 0.42);
+    vec3 baseColor = mix(chargeColor, strikeColor, strikeMix);
+    baseColor = mix(baseColor, hitColor, hitMix);
+
+    float intensity = activity * pulse * (0.6 * vignette + 0.4 * cross) * (0.35 + 0.65 * distanceFade);
+    intensity = saturate(intensity);
+
+    fragColor = vec4(baseColor * intensity, intensity * 0.9);
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "orbital_railgun:post/compat_overlay",
+  "fragment": "orbital_railgun:post/compat_overlay",
+  "attributes": [ "Position", "UV0" ],
+  "uniforms": [
+    { "name": "iTime", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "StrikeActive", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "SelectionActive", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "Distance", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "HitKind", "type": "int", "count": 1, "values": [ 0 ] },
+    { "name": "OutSize", "type": "float", "count": 2, "values": [ 1.0, 1.0 ] }
+  ]
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.vsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.vsh
@@ -1,0 +1,11 @@
+#version 150
+
+in vec3 Position;
+in vec2 UV0;
+
+out vec2 texCoord;
+
+void main() {
+    texCoord = UV0;
+    gl_Position = vec4(Position, 1.0);
+}


### PR DESCRIPTION
## Summary
- add a ShaderModBridge and client config options so Iris/Oculus shader packs can be detected and logged
- introduce a PostChainManager that swaps between the existing post chain and a fallback overlay when shader packs are active
- provide a lightweight compatibility overlay shader that renders via the main framebuffer without breaking shader packs

## Testing
- gradle build

------
https://chatgpt.com/codex/tasks/task_e_68e1920a251c83259a4035d35b93ed33