### PR TITLE
Add Iris shader pack compatibility overlay

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
@@ -37,6 +37,7 @@ public class ForgeOrbitalRailgunMod {
         modBus.addListener(this::onCommonSetup);
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, OrbitalRailgunConfig.COMMON_SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, OrbitalRailgunConfig.CLIENT_SPEC);
 
         OrbitalRailgunStrikeManager.register();
     }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -1,175 +1,44 @@
 package net.tysontheember.orbitalrailgun.client;
 
-import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.railgun.PostChainManager;
 import net.tysontheember.orbitalrailgun.client.railgun.RailgunState;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.C2S_RequestFire;
 import net.tysontheember.orbitalrailgun.network.Network;
-import com.mojang.blaze3d.shaders.Uniform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.EffectInstance;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.client.renderer.PostPass;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
-import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
-import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.event.ViewportEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
-import org.joml.Matrix4f;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = ForgeOrbitalRailgunMod.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ClientEvents {
-    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
-    private static final Field PASSES_FIELD = findPassesField();
-    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
-            ForgeOrbitalRailgunMod.id("strike"),
-            ForgeOrbitalRailgunMod.id("gui")
-    );
-
-    private static PostChain railgunChain;
-    private static boolean chainReady;
-    private static int chainWidth = -1;
-    private static int chainHeight = -1;
-
     private static boolean attackWasDown;
 
     static {
-        if (PASSES_FIELD != null) {
-            PASSES_FIELD.setAccessible(true);
-        } else {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to locate orbital railgun post chain passes field");
-        }
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEvents::onRegisterReloadListeners);
+        PostChainManager.init();
     }
 
     private ClientEvents() {}
 
-    private static void onRegisterReloadListeners(RegisterClientReloadListenersEvent event) {
-        event.registerReloadListener(new SimplePreparableReloadListener<Void>() {
-            @Override
-            protected Void prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
-                return null;
-            }
-
-            @Override
-            protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
-                ClientEvents.reloadChain(resourceManager);
-            }
-        });    }
-
-    private static void reloadChain(ResourceManager resourceManager) {
-        Minecraft minecraft = Minecraft.getInstance();
-        closeChain();
-        if (minecraft.getMainRenderTarget() == null) {
-            chainReady = false;
-            return;
-        }
-
-        try {
-            railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, minecraft.getMainRenderTarget(), RAILGUN_CHAIN_ID);
-            chainReady = true;
-            chainWidth = -1;
-            chainHeight = -1;
-            resizeChain(minecraft);
-        } catch (IOException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
-            chainReady = false;
-            closeChain();
-        }
-    }
-
-    private static void resizeChain(Minecraft minecraft) {
-        if (railgunChain == null) {
-            return;
-        }
-        RenderTarget mainTarget = minecraft.getMainRenderTarget();
-        if (mainTarget == null) {
-            return;
-        }
-        int width = mainTarget.width;
-        int height = mainTarget.height;
-        if (width == chainWidth && height == chainHeight) {
-            return;
-        }
-        railgunChain.resize(width, height);
-        chainWidth = width;
-        chainHeight = height;
-    }
-
     @SubscribeEvent
     public static void onScreenRender(ScreenEvent.Render.Post event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        resizeChain(Minecraft.getInstance());
+        PostChainManager.onResize();
     }
 
     @SubscribeEvent
     public static void onRenderStage(RenderLevelStageEvent event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
-            return;
-        }
-
-        Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.level == null) {
-            return;
-        }
-
-        RailgunState state = RailgunState.getInstance();
-        Level level = minecraft.level;
-        boolean strikeActive = state.isStrikeActive() && state.getStrikeDimension() != null && state.getStrikeDimension().equals(level.dimension());
-        boolean chargeActive = state.isCharging();
-        if (!strikeActive && !chargeActive) {
-            return;
-        }
-
-        resizeChain(minecraft);
-
-        float timeSeconds = strikeActive
-                ? state.getStrikeSeconds(event.getPartialTick())
-                : state.getChargeSeconds(event.getPartialTick());
-
-        Matrix4f projection = new Matrix4f(event.getProjectionMatrix());
-        Matrix4f inverseProjection = new Matrix4f(projection).invert();
-        Matrix4f modelView = new Matrix4f(event.getPoseStack().last().pose());
-        Vec3 cameraPos = event.getCamera().getPosition();
-
-        Vec3 targetPos = strikeActive ? state.getStrikePos() : state.getHitPos();
-        float distance = strikeActive
-                ? (float) cameraPos.distanceTo(state.getStrikePos())
-                : state.getHitDistance();
-        float isBlockHit = state.getHitKind() != RailgunState.HitKind.NONE ? 1.0F : 0.0F;
-
-        applyUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds, isBlockHit, strikeActive, state);
-
-        railgunChain.process(event.getPartialTick());
+        PostChainManager.render(event, RailgunState.getInstance());
     }
 
     @SubscribeEvent
@@ -180,6 +49,7 @@ public final class ClientEvents {
         Minecraft minecraft = Minecraft.getInstance();
         RailgunState state = RailgunState.getInstance();
         state.tick(minecraft);
+        PostChainManager.tick(minecraft);
 
         LocalPlayer player = minecraft.player;
         boolean attackDown = player != null && minecraft.options != null && minecraft.options.keyAttack.isDown();
@@ -215,142 +85,5 @@ public final class ClientEvents {
             double baseFov = Minecraft.getInstance().options.fov().get();
             event.setFOV(baseFov);
         }
-    }
-
-    private static void applyUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos, Vec3 targetPos,
-                                      float distance, float timeSeconds, float isBlockHit, boolean strikeActive, RailgunState state) {
-        List<PostPass> passes = getPasses();
-        if (passes.isEmpty()) {
-            return;
-        }
-
-        Minecraft minecraft = Minecraft.getInstance();
-        RenderTarget renderTarget = minecraft.getMainRenderTarget();
-        if (renderTarget == null) {
-            return;
-        }
-
-        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
-        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
-
-        for (PostPass pass : passes) {
-            EffectInstance effect = pass.getEffect();
-            if (effect == null) {
-                continue;
-            }
-
-            ResourceLocation passName = getPassName(pass);
-            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
-
-            setMatrix(effect, "ProjMat", projection);
-            if (expectsModelViewMatrix) {
-                setMatrix(effect, "ModelViewMat", modelView);
-            }
-            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
-            setVec3(effect, "CameraPosition", cameraPos);
-            setVec3(effect, "BlockPosition", targetPos);
-            setVec3(effect, "HitPos", targetPos);
-            setVec2(effect, "OutSize", width, height);
-            setFloat(effect, "iTime", timeSeconds);
-            setFloat(effect, "Distance", distance);
-            setFloat(effect, "IsBlockHit", isBlockHit);
-            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
-            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
-            setInt(effect, "HitKind", state.getHitKind().ordinal());
-        }
-    }
-
-    private static ResourceLocation getPassName(PostPass pass) {
-        String name = pass.getName();
-        return name != null ? ResourceLocation.tryParse(name) : null;
-    }
-
-    private static List<PostPass> getPasses() {
-        if (railgunChain == null) {
-            return Collections.emptyList();
-        }
-        if (PASSES_FIELD == null) {
-            return Collections.emptyList();
-        }
-        try {
-            Object value = PASSES_FIELD.get(railgunChain);
-            if (value instanceof List<?> list) {
-                @SuppressWarnings("unchecked")
-                List<PostPass> passes = (List<PostPass>) list;
-                return passes;
-            }
-            ForgeOrbitalRailgunMod.LOGGER.error(
-                    "Orbital railgun post chain passes had unexpected type: {}",
-                    value == null ? "null" : value.getClass().getName()
-            );
-        } catch (IllegalAccessException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
-            return Collections.emptyList();
-        }
-        return Collections.emptyList();
-    }
-
-    private static Field findPassesField() {
-        try {
-            return ObfuscationReflectionHelper.findField(PostChain.class, "passes");
-        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
-            try {
-                return ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
-            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
-                ForgeOrbitalRailgunMod.LOGGER.error(
-                        "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
-                        exception
-                );
-                return null;
-            }
-        }
-    }
-
-    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(matrix);
-        }
-    }
-
-    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
-        }
-    }
-
-    private static void setVec2(EffectInstance effect, String name, float x, float y) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(x, y);
-        }
-    }
-
-    private static void setFloat(EffectInstance effect, String name, float value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void setInt(EffectInstance effect, String name, int value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void closeChain() {
-        if (railgunChain != null) {
-            try {
-                railgunChain.close();
-            } catch (Exception ignored) {
-            }
-            railgunChain = null;
-        }
-        chainReady = false;
-        chainWidth = -1;
-        chainHeight = -1;
     }
 }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
@@ -1,0 +1,68 @@
+package net.tysontheember.orbitalrailgun.client;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.ModList;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@OnlyIn(Dist.CLIENT)
+public final class ShaderModBridge {
+    private static final String IRIS_API_CLASS = "net.irisshaders.iris.api.v0.IrisApi";
+
+    private static final boolean IRIS_OR_OCULUS_LOADED = ModList.get().isLoaded("iris") || ModList.get().isLoaded("oculus");
+
+    private static boolean attemptedInit;
+    private static Object irisApiInstance;
+    private static Method shaderPackInUseMethod;
+
+    private ShaderModBridge() {}
+
+    public static boolean isShaderModPresent() {
+        return IRIS_OR_OCULUS_LOADED;
+    }
+
+    public static boolean isShaderPackInUse() {
+        if (!isShaderModPresent()) {
+            return false;
+        }
+        ensureIrisApi();
+        if (irisApiInstance != null && shaderPackInUseMethod != null) {
+            try {
+                Object result = shaderPackInUseMethod.invoke(irisApiInstance);
+                if (result instanceof Boolean bool) {
+                    return bool;
+                }
+            } catch (IllegalAccessException | InvocationTargetException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.warn("Failed to query Iris shader pack state", exception);
+                irisApiInstance = null;
+                shaderPackInUseMethod = null;
+                attemptedInit = false;
+            }
+        }
+        return false;
+    }
+
+    private static void ensureIrisApi() {
+        if (attemptedInit || !isShaderModPresent()) {
+            return;
+        }
+        attemptedInit = true;
+        try {
+            Class<?> irisApiClass = Class.forName(IRIS_API_CLASS);
+            Method getInstance = irisApiClass.getMethod("getInstance");
+            Method isShaderPackInUse = irisApiClass.getMethod("isShaderPackInUse");
+            Object instance = getInstance.invoke(null);
+            if (instance != null) {
+                irisApiInstance = instance;
+                shaderPackInUseMethod = isShaderPackInUse;
+            }
+        } catch (ClassNotFoundException ignored) {
+            ForgeOrbitalRailgunMod.LOGGER.debug("Iris API class was not found while attempting to initialize shader bridge");
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.warn("Unable to initialize Iris shader bridge", exception);
+        }
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
@@ -1,0 +1,465 @@
+package net.tysontheember.orbitalrailgun.client.railgun;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.shaders.Uniform;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EffectInstance;
+import net.minecraft.client.renderer.PostChain;
+import net.minecraft.client.renderer.PostPass;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.ShaderModBridge;
+import net.tysontheember.orbitalrailgun.config.OrbitalRailgunConfig;
+import org.joml.Matrix4f;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@OnlyIn(Dist.CLIENT)
+public final class PostChainManager {
+    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
+    private static final ResourceLocation COMPAT_OVERLAY_ID = ForgeOrbitalRailgunMod.id("shaders/post/compat_overlay.json");
+    private static final Field PASSES_FIELD = findPassesField();
+    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
+        ForgeOrbitalRailgunMod.id("strike"),
+        ForgeOrbitalRailgunMod.id("gui"),
+        ForgeOrbitalRailgunMod.id("compat_overlay")
+    );
+
+    private static PostChain railgunChain;
+    private static EffectInstance compatOverlay;
+
+    private static boolean chainReady;
+    private static boolean compatReady;
+    private static boolean compatMode;
+    private static boolean shaderPackActive;
+    private static boolean disabledByConfig;
+    private static boolean loggedState;
+
+    private static int chainWidth = -1;
+    private static int chainHeight = -1;
+
+    private static ResourceManager lastResourceManager;
+
+    private PostChainManager() {}
+
+    public static void init() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(PostChainManager::registerReloadListener);
+    }
+
+    private static void registerReloadListener(RegisterClientReloadListenersEvent event) {
+        event.registerReloadListener(new SimplePreparableReloadListener<Void>() {
+            @Override
+            protected Void prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
+                return null;
+            }
+
+            @Override
+            protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
+                lastResourceManager = resourceManager;
+                rebuild(Minecraft.getInstance());
+            }
+        });
+    }
+
+    public static void tick(Minecraft minecraft) {
+        boolean currentShaderState = ShaderModBridge.isShaderPackInUse();
+        boolean desiredCompat = shouldUseCompat(currentShaderState);
+        boolean shouldDisable = currentShaderState && OrbitalRailgunConfig.CLIENT.disableWithShaderpack.get();
+        if (currentShaderState != shaderPackActive || desiredCompat != compatMode || shouldDisable != disabledByConfig) {
+            shaderPackActive = currentShaderState;
+            disabledByConfig = shouldDisable;
+            compatMode = desiredCompat;
+            rebuild(minecraft);
+        }
+    }
+
+    public static void onResize() {
+        if (!compatMode) {
+            resizeChain(Minecraft.getInstance());
+        }
+    }
+
+    public static void render(RenderLevelStageEvent event, RailgunState state) {
+        if (disabledByConfig) {
+            return;
+        }
+        RenderLevelStageEvent.Stage stage = compatMode ? RenderLevelStageEvent.Stage.AFTER_WEATHER : RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS;
+        if (event.getStage() != stage) {
+            return;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) {
+            return;
+        }
+
+        if (!ensureReady(minecraft)) {
+            return;
+        }
+
+        Level level = minecraft.level;
+        boolean strikeActive = state.isStrikeActive() && state.getStrikeDimension() != null && state.getStrikeDimension().equals(level.dimension());
+        boolean chargeActive = state.isCharging();
+        if (!strikeActive && !chargeActive) {
+            return;
+        }
+
+        RenderTarget mainTarget = RenderSystem.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+
+        float width = mainTarget.width > 0 ? mainTarget.width : mainTarget.viewWidth;
+        float height = mainTarget.height > 0 ? mainTarget.height : mainTarget.viewHeight;
+
+        float timeSeconds = strikeActive
+            ? state.getStrikeSeconds(event.getPartialTick())
+            : state.getChargeSeconds(event.getPartialTick());
+
+        Matrix4f projection = new Matrix4f(event.getProjectionMatrix());
+        Matrix4f inverseProjection = new Matrix4f(projection).invert();
+        Matrix4f modelView = new Matrix4f(event.getPoseStack().last().pose());
+        Vec3 cameraPos = event.getCamera().getPosition();
+
+        Vec3 targetPos = strikeActive ? state.getStrikePos() : state.getHitPos();
+        float distance = strikeActive
+            ? (float) cameraPos.distanceTo(state.getStrikePos())
+            : state.getHitDistance();
+        float isBlockHit = state.getHitKind() != RailgunState.HitKind.NONE ? 1.0F : 0.0F;
+
+        applyUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds, isBlockHit, strikeActive, state, width, height);
+        maybeLogState();
+
+        if (compatMode) {
+            renderCompatOverlay(mainTarget, width, height);
+        } else if (railgunChain != null) {
+            railgunChain.process(event.getPartialTick());
+        }
+    }
+
+    private static boolean ensureReady(Minecraft minecraft) {
+        if (compatMode) {
+            return compatReady && compatOverlay != null;
+        }
+        if (!chainReady || railgunChain == null) {
+            return false;
+        }
+        resizeChain(minecraft);
+        return true;
+    }
+
+    private static void rebuild(Minecraft minecraft) {
+        closeChain();
+        closeOverlay();
+
+        if (minecraft == null) {
+            return;
+        }
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            chainReady = false;
+            compatReady = false;
+            return;
+        }
+
+        shaderPackActive = ShaderModBridge.isShaderPackInUse();
+        boolean forceVanilla = OrbitalRailgunConfig.CLIENT.forceVanillaPostChain.get();
+        disabledByConfig = shaderPackActive && OrbitalRailgunConfig.CLIENT.disableWithShaderpack.get();
+        compatMode = shouldUseCompat(shaderPackActive) && !disabledByConfig && !forceVanilla;
+        loggedState = false;
+
+        ResourceManager resourceManager = lastResourceManager != null ? lastResourceManager : minecraft.getResourceManager();
+
+        if (compatMode) {
+            try {
+                compatOverlay = new EffectInstance(COMPAT_OVERLAY_ID);
+                compatReady = true;
+            } catch (IOException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun compatibility overlay", exception);
+                compatOverlay = null;
+                compatReady = false;
+            }
+        } else if (!disabledByConfig || !shaderPackActive) {
+            try {
+                railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, minecraft.getMainRenderTarget(), RAILGUN_CHAIN_ID);
+                chainReady = true;
+                chainWidth = -1;
+                chainHeight = -1;
+                resizeChain(minecraft);
+            } catch (IOException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
+                chainReady = false;
+                closeChain();
+            }
+        }
+
+        maybeLogState();
+    }
+
+    private static void renderCompatOverlay(RenderTarget mainTarget, float width, float height) {
+        if (!compatReady || compatOverlay == null) {
+            return;
+        }
+
+        mainTarget.bindWrite(false);
+
+        compatOverlay.setSampler("DiffuseSampler", () -> mainTarget.getColorTextureId());
+        if (mainTarget.getDepthTextureId() >= 0) {
+            compatOverlay.setSampler("DepthSampler", () -> mainTarget.getDepthTextureId());
+        }
+
+        RenderSystem.depthMask(false);
+        RenderSystem.disableDepthTest();
+        RenderSystem.enableBlend();
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA.value, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA.value, GlStateManager.SourceFactor.ONE.value, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA.value);
+        RenderSystem.bindTexture(0);
+        compatOverlay.apply();
+
+        BufferBuilder bufferBuilder = Tesselator.getInstance().getBuilder();
+        bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+        bufferBuilder.vertex(0.0D, height, 0.0D).uv(0.0F, 1.0F).endVertex();
+        bufferBuilder.vertex(width, height, 0.0D).uv(1.0F, 1.0F).endVertex();
+        bufferBuilder.vertex(width, 0.0D, 0.0D).uv(1.0F, 0.0F).endVertex();
+        bufferBuilder.vertex(0.0D, 0.0D, 0.0D).uv(0.0F, 0.0F).endVertex();
+        Tesselator.getInstance().end();
+        compatOverlay.clear();
+
+        RenderSystem.disableBlend();
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthMask(true);
+    }
+
+    private static void applyUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos, Vec3 targetPos,
+                                      float distance, float timeSeconds, float isBlockHit, boolean strikeActive, RailgunState state,
+                                      float width, float height) {
+        List<EffectInstance> effects = getActiveEffects();
+        if (effects.isEmpty()) {
+            return;
+        }
+
+        for (EffectInstance effect : effects) {
+            if (effect == null) {
+                continue;
+            }
+            ResourceLocation passName = getEffectName(effect);
+            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
+
+            setMatrix(effect, "ProjMat", projection);
+            if (expectsModelViewMatrix) {
+                setMatrix(effect, "ModelViewMat", modelView);
+            }
+            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
+            setVec3(effect, "CameraPosition", cameraPos);
+            setVec3(effect, "BlockPosition", targetPos);
+            setVec3(effect, "HitPos", targetPos);
+            setVec2(effect, "OutSize", width, height);
+            setFloat(effect, "iTime", timeSeconds);
+            setFloat(effect, "Distance", distance);
+            setFloat(effect, "IsBlockHit", isBlockHit);
+            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
+            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
+            setInt(effect, "HitKind", state.getHitKind().ordinal());
+        }
+    }
+
+    private static ResourceLocation getEffectName(EffectInstance effect) {
+        String name = effect.getName();
+        return name != null ? ResourceLocation.tryParse(name) : null;
+    }
+
+    private static List<EffectInstance> getActiveEffects() {
+        if (compatMode) {
+            return compatOverlay != null ? List.of(compatOverlay) : Collections.emptyList();
+        }
+        List<PostPass> passes = getPasses();
+        if (passes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<EffectInstance> effects = new ArrayList<>(passes.size());
+        for (PostPass pass : passes) {
+            effects.add(pass.getEffect());
+        }
+        return effects;
+    }
+
+    private static List<PostPass> getPasses() {
+        if (railgunChain == null || PASSES_FIELD == null) {
+            return Collections.emptyList();
+        }
+        try {
+            Object value = PASSES_FIELD.get(railgunChain);
+            if (value instanceof List<?> list) {
+                @SuppressWarnings("unchecked")
+                List<PostPass> passes = (List<PostPass>) list;
+                return passes;
+            }
+            ForgeOrbitalRailgunMod.LOGGER.error("Orbital railgun post chain passes had unexpected type: {}", value == null ? "null" : value.getClass().getName());
+        } catch (IllegalAccessException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
+        }
+        return Collections.emptyList();
+    }
+
+    private static void resizeChain(Minecraft minecraft) {
+        if (railgunChain == null) {
+            return;
+        }
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+        int width = mainTarget.width;
+        int height = mainTarget.height;
+        if (width == chainWidth && height == chainHeight) {
+            return;
+        }
+        railgunChain.resize(width, height);
+        chainWidth = width;
+        chainHeight = height;
+    }
+
+    private static Field findPassesField() {
+        try {
+            return ObfuscationReflectionHelper.findField(PostChain.class, "passes");
+        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
+            try {
+                return ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
+            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.error("Unable to find passes field on PostChain using Mojmap or SRG identifiers", exception);
+                return null;
+            }
+        }
+    }
+
+    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
+        if (effect == null) {
+            return;
+        }
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(matrix);
+        }
+    }
+
+    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
+        if (effect == null) {
+            return;
+        }
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
+        }
+    }
+
+    private static void setVec2(EffectInstance effect, String name, float x, float y) {
+        if (effect == null) {
+            return;
+        }
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(x, y);
+        }
+    }
+
+    private static void setFloat(EffectInstance effect, String name, float value) {
+        if (effect == null) {
+            return;
+        }
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(value);
+        }
+    }
+
+    private static void setInt(EffectInstance effect, String name, int value) {
+        if (effect == null) {
+            return;
+        }
+        Uniform uniform = effect.getUniform(name);
+        if (uniform != null) {
+            uniform.set(value);
+        }
+    }
+
+    private static void closeChain() {
+        if (railgunChain != null) {
+            try {
+                railgunChain.close();
+            } catch (Exception ignored) {
+            }
+            railgunChain = null;
+        }
+        chainReady = false;
+        chainWidth = -1;
+        chainHeight = -1;
+    }
+
+    private static void closeOverlay() {
+        if (compatOverlay != null) {
+            try {
+                compatOverlay.close();
+            } catch (Exception ignored) {
+            }
+            compatOverlay = null;
+        }
+        compatReady = false;
+    }
+
+    private static boolean shouldUseCompat(boolean shaderActive) {
+        if (!shaderActive) {
+            return false;
+        }
+        if (!ShaderModBridge.isShaderModPresent()) {
+            return false;
+        }
+        if (OrbitalRailgunConfig.CLIENT.forceVanillaPostChain.get()) {
+            return false;
+        }
+        if (OrbitalRailgunConfig.CLIENT.disableWithShaderpack.get()) {
+            return false;
+        }
+        return true;
+    }
+
+    private static void maybeLogState() {
+        if (!OrbitalRailgunConfig.CLIENT.logIrisState.get() || loggedState) {
+            return;
+        }
+        if (shaderPackActive) {
+            if (disabledByConfig) {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected: orbital railgun effects disabled by configuration");
+            } else if (compatMode && compatReady) {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected: enabling compatibility mode");
+            } else if (compatMode) {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected but compatibility overlay failed to initialize");
+            } else {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected but running vanilla post chain");
+            }
+        } else if (!compatMode) {
+            ForgeOrbitalRailgunMod.LOGGER.info("No shader pack detected: running vanilla post chain");
+        }
+        loggedState = true;
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunConfig.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunConfig.java
@@ -5,12 +5,18 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public final class OrbitalRailgunConfig {
     public static final ForgeConfigSpec COMMON_SPEC;
+    public static final ForgeConfigSpec CLIENT_SPEC;
     public static final Common COMMON;
+    public static final Client CLIENT;
 
     static {
-        Pair<Common, ForgeConfigSpec> pair = new ForgeConfigSpec.Builder().configure(Common::new);
-        COMMON_SPEC = pair.getRight();
-        COMMON = pair.getLeft();
+        Pair<Common, ForgeConfigSpec> commonPair = new ForgeConfigSpec.Builder().configure(Common::new);
+        COMMON_SPEC = commonPair.getRight();
+        COMMON = commonPair.getLeft();
+
+        Pair<Client, ForgeConfigSpec> clientPair = new ForgeConfigSpec.Builder().configure(Client::new);
+        CLIENT_SPEC = clientPair.getRight();
+        CLIENT = clientPair.getLeft();
     }
 
     private OrbitalRailgunConfig() {}
@@ -31,6 +37,26 @@ public final class OrbitalRailgunConfig {
             suckEntities = builder
                 .comment("Whether entities are pulled towards the strike before detonation.")
                 .define("suckEntities", true);
+            builder.pop();
+        }
+    }
+
+    public static final class Client {
+        public final ForgeConfigSpec.BooleanValue disableWithShaderpack;
+        public final ForgeConfigSpec.BooleanValue logIrisState;
+        public final ForgeConfigSpec.BooleanValue forceVanillaPostChain;
+
+        private Client(ForgeConfigSpec.Builder builder) {
+            builder.push("compat");
+            disableWithShaderpack = builder
+                .comment("Disable the orbital railgun overlays when a shader pack is active.")
+                .define("disableWithShaderpack", false);
+            logIrisState = builder
+                .comment("Log shader pack compatibility decisions whenever resources reload.")
+                .define("logIrisState", true);
+            forceVanillaPostChain = builder
+                .comment("Force the vanilla post-processing chain to run even when a shader pack is detected.")
+                .define("forceVanillaPostChain", false);
             builder.pop();
         }
     }

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
@@ -1,0 +1,29 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "orbital_railgun:compat_overlay",
+  "fragment": "orbital_railgun:compat_overlay",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "DepthSampler" }
+  ],
+  "uniforms": [
+    { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "InverseTransformMatrix", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize", "type": "float", "count": 2, "values": [ 1.0, 1.0 ] },
+    { "name": "CameraPosition", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+    { "name": "BlockPosition", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+    { "name": "HitPos", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+    { "name": "iTime", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "StrikeActive", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "SelectionActive", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "IsBlockHit", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "Distance", "type": "float", "count": 1, "values": [ 0.0 ] },
+    { "name": "HitKind", "type": "int", "count": 1, "values": [ 0 ] }
+  ]
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
@@ -1,0 +1,82 @@
+#version 330 compatibility
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D DepthSampler;
+uniform mat4 InverseTransformMatrix;
+uniform mat4 ModelViewMat;
+uniform vec3 CameraPosition;
+uniform vec3 BlockPosition;
+uniform vec3 HitPos;
+uniform float iTime;
+uniform float StrikeActive;
+uniform float SelectionActive;
+uniform float Distance;
+uniform float IsBlockHit;
+uniform int HitKind;
+
+in vec2 texCoord;
+in float viewWidth;
+in float viewHeight;
+
+out vec4 fragColor;
+
+vec3 worldPos(vec3 point) {
+    vec3 ndc = point * 2.0 - 1.0;
+    vec4 homPos = InverseTransformMatrix * vec4(ndc, 1.0);
+    float invW = homPos.w == 0.0 ? 1.0 : 1.0 / homPos.w;
+    vec3 viewPos = homPos.xyz * invW;
+    return (inverse(ModelViewMat) * vec4(viewPos, 1.0)).xyz + CameraPosition;
+}
+
+float softVignette(vec2 uv) {
+    float len = dot(uv, uv);
+    return smoothstep(1.0, 0.2, len);
+}
+
+void main() {
+    vec3 baseColor = texture(DiffuseSampler, texCoord).rgb;
+    float depth = texture(DepthSampler, texCoord).r;
+
+    float strikeFactor = clamp(StrikeActive, 0.0, 1.0);
+    float chargeFactor = clamp(SelectionActive, 0.0, 1.0);
+    float distanceFactor = clamp(1.0 / (1.0 + Distance * 0.05), 0.25, 1.0);
+
+    vec3 overlayColor = baseColor;
+
+    if (strikeFactor > 0.0) {
+        vec3 worldDepth = worldPos(vec3(texCoord, depth)) - BlockPosition;
+        float radial = length(worldDepth.xz);
+        float pulse = 0.6 + 0.4 * sin(iTime * 2.5);
+        float glow = exp(-radial * 0.04) * pulse;
+        overlayColor += vec3(0.35, 0.7, 1.0) * glow * strikeFactor;
+    }
+
+    if (chargeFactor > 0.0) {
+        vec3 towardsHit = worldPos(vec3(texCoord, depth)) - HitPos;
+        float focus = exp(-dot(towardsHit, towardsHit) * 0.02);
+        overlayColor = mix(overlayColor, overlayColor + vec3(0.12, 0.6, 0.28) * focus, chargeFactor * 0.75);
+    }
+
+    vec2 centered = texCoord - vec2(0.5);
+    float aspect = viewHeight <= 0.0 ? 1.0 : viewWidth / viewHeight;
+    centered.x *= aspect;
+
+    float cross = max(0.0, 0.025 - abs(centered.x)) + max(0.0, 0.025 - abs(centered.y));
+    float crossPulse = 0.5 + 0.5 * sin(iTime * 6.28318);
+    float crossHighlight = cross * (0.6 + 0.4 * crossPulse) * distanceFactor;
+
+    float ring = exp(-dot(centered, centered) * 24.0);
+    float hitBoost = clamp(IsBlockHit + strikeFactor + chargeFactor, 0.0, 1.0);
+
+    vec3 hitTint = mix(vec3(0.18, 0.8, 0.45), vec3(0.45, 0.7, 1.0), strikeFactor);
+    if (HitKind == 2) {
+        hitTint = vec3(0.9, 0.55, 0.3);
+    }
+
+    overlayColor = mix(overlayColor, overlayColor + hitTint * (ring + crossHighlight), clamp(hitBoost, 0.0, 1.0));
+
+    float vignette = softVignette(centered * 1.35);
+    overlayColor *= vignette;
+
+    fragColor = vec4(overlayColor, 1.0);
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.vsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.vsh
@@ -1,0 +1,19 @@
+#version 330 compatibility
+
+in vec4 Position;
+
+uniform mat4 ProjMat;
+uniform vec2 OutSize;
+
+out vec2 texCoord;
+out float viewWidth;
+out float viewHeight;
+
+void main() {
+    vec4 outPos = ProjMat * vec4(Position.xy, 0.0, 1.0);
+    gl_Position = vec4(outPos.xy, 0.0, 1.0);
+
+    texCoord = Position.xy / OutSize;
+    viewWidth = OutSize.x;
+    viewHeight = OutSize.y;
+}


### PR DESCRIPTION
## Summary
- add a ShaderModBridge helper and client config toggles to detect Iris/Oculus shader pack usage
- replace the old post-processing pipeline with PostChainManager, rendering overlays after shader packs complete
- provide a fallback compatibility shader chain for overlay effects when a shader pack is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1920a251c83259a4035d35b93ed33