### PR TITLE
Add shader pack compatibility pipeline

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/ForgeOrbitalRailgunMod.java
@@ -1,5 +1,6 @@
 package net.tysontheember.orbitalrailgun;
 
+import net.tysontheember.orbitalrailgun.config.OrbitalRailgunClientConfig;
 import net.tysontheember.orbitalrailgun.config.OrbitalRailgunConfig;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.Network;
@@ -36,6 +37,7 @@ public class ForgeOrbitalRailgunMod {
         ITEMS.register(modBus);
         modBus.addListener(this::onCommonSetup);
 
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, OrbitalRailgunClientConfig.CLIENT_SPEC);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, OrbitalRailgunConfig.COMMON_SPEC);
 
         OrbitalRailgunStrikeManager.register();

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientEvents.java
@@ -1,139 +1,44 @@
 package net.tysontheember.orbitalrailgun.client;
 
-import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.railgun.PostChainManager;
 import net.tysontheember.orbitalrailgun.client.railgun.RailgunState;
 import net.tysontheember.orbitalrailgun.item.OrbitalRailgunItem;
 import net.tysontheember.orbitalrailgun.network.C2S_RequestFire;
 import net.tysontheember.orbitalrailgun.network.Network;
-import com.mojang.blaze3d.shaders.Uniform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.EffectInstance;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.client.renderer.PostPass;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
-import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.event.ViewportEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import org.joml.Matrix4f;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = ForgeOrbitalRailgunMod.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ClientEvents {
-    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
-    private static final Field PASSES_FIELD = findPassesField();
-    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
-            ForgeOrbitalRailgunMod.id("strike"),
-            ForgeOrbitalRailgunMod.id("gui")
-    );
-
-    private static PostChain railgunChain;
-    private static boolean chainReady;
-    private static int chainWidth = -1;
-    private static int chainHeight = -1;
-
     private static boolean attackWasDown;
-
-    static {
-        if (PASSES_FIELD != null) {
-            PASSES_FIELD.setAccessible(true);
-        } else {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to locate orbital railgun post chain passes field");
-        }
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEvents::onRegisterReloadListeners);
-    }
 
     private ClientEvents() {}
 
-    private static void onRegisterReloadListeners(RegisterClientReloadListenersEvent event) {
-        event.registerReloadListener(new SimplePreparableReloadListener<Void>() {
-            @Override
-            protected Void prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
-                return null;
-            }
-
-            @Override
-            protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
-                ClientEvents.reloadChain(resourceManager);
-            }
-        });    }
-
-    private static void reloadChain(ResourceManager resourceManager) {
-        Minecraft minecraft = Minecraft.getInstance();
-        closeChain();
-        if (minecraft.getMainRenderTarget() == null) {
-            chainReady = false;
-            return;
-        }
-
-        try {
-            railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, minecraft.getMainRenderTarget(), RAILGUN_CHAIN_ID);
-            chainReady = true;
-            chainWidth = -1;
-            chainHeight = -1;
-            resizeChain(minecraft);
-        } catch (IOException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
-            chainReady = false;
-            closeChain();
-        }
-    }
-
-    private static void resizeChain(Minecraft minecraft) {
-        if (railgunChain == null) {
-            return;
-        }
-        RenderTarget mainTarget = minecraft.getMainRenderTarget();
-        if (mainTarget == null) {
-            return;
-        }
-        int width = mainTarget.width;
-        int height = mainTarget.height;
-        if (width == chainWidth && height == chainHeight) {
-            return;
-        }
-        railgunChain.resize(width, height);
-        chainWidth = width;
-        chainHeight = height;
-    }
-
     @SubscribeEvent
     public static void onScreenRender(ScreenEvent.Render.Post event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        resizeChain(Minecraft.getInstance());
+        PostChainManager.resizeIfNeeded();
     }
 
     @SubscribeEvent
     public static void onRenderStage(RenderLevelStageEvent event) {
-        if (!chainReady || railgunChain == null) {
-            return;
-        }
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+        PostChainManager.ensureState();
+        if (!PostChainManager.isStageValid(event.getStage())) {
             return;
         }
 
@@ -150,8 +55,6 @@ public final class ClientEvents {
             return;
         }
 
-        resizeChain(minecraft);
-
         float timeSeconds = strikeActive
                 ? state.getStrikeSeconds(event.getPartialTick())
                 : state.getChargeSeconds(event.getPartialTick());
@@ -167,9 +70,8 @@ public final class ClientEvents {
                 : state.getHitDistance();
         float isBlockHit = state.getHitKind() != RailgunState.HitKind.NONE ? 1.0F : 0.0F;
 
-        applyUniforms(modelView, projection, inverseProjection, cameraPos, targetPos, distance, timeSeconds, isBlockHit, strikeActive, state);
-
-        railgunChain.process(event.getPartialTick());
+        PostChainManager.render(event, state, strikeActive, state.isCharging(), timeSeconds, projection, inverseProjection,
+                modelView, cameraPos, targetPos, distance, isBlockHit);
     }
 
     @SubscribeEvent
@@ -215,142 +117,5 @@ public final class ClientEvents {
             double baseFov = Minecraft.getInstance().options.fov().get();
             event.setFOV(baseFov);
         }
-    }
-
-    private static void applyUniforms(Matrix4f modelView, Matrix4f projection, Matrix4f inverseProjection, Vec3 cameraPos, Vec3 targetPos,
-                                      float distance, float timeSeconds, float isBlockHit, boolean strikeActive, RailgunState state) {
-        List<PostPass> passes = getPasses();
-        if (passes.isEmpty()) {
-            return;
-        }
-
-        Minecraft minecraft = Minecraft.getInstance();
-        RenderTarget renderTarget = minecraft.getMainRenderTarget();
-        if (renderTarget == null) {
-            return;
-        }
-
-        float width = renderTarget.width > 0 ? renderTarget.width : renderTarget.viewWidth;
-        float height = renderTarget.height > 0 ? renderTarget.height : renderTarget.viewHeight;
-
-        for (PostPass pass : passes) {
-            EffectInstance effect = pass.getEffect();
-            if (effect == null) {
-                continue;
-            }
-
-            ResourceLocation passName = getPassName(pass);
-            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
-
-            setMatrix(effect, "ProjMat", projection);
-            if (expectsModelViewMatrix) {
-                setMatrix(effect, "ModelViewMat", modelView);
-            }
-            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
-            setVec3(effect, "CameraPosition", cameraPos);
-            setVec3(effect, "BlockPosition", targetPos);
-            setVec3(effect, "HitPos", targetPos);
-            setVec2(effect, "OutSize", width, height);
-            setFloat(effect, "iTime", timeSeconds);
-            setFloat(effect, "Distance", distance);
-            setFloat(effect, "IsBlockHit", isBlockHit);
-            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
-            setFloat(effect, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
-            setInt(effect, "HitKind", state.getHitKind().ordinal());
-        }
-    }
-
-    private static ResourceLocation getPassName(PostPass pass) {
-        String name = pass.getName();
-        return name != null ? ResourceLocation.tryParse(name) : null;
-    }
-
-    private static List<PostPass> getPasses() {
-        if (railgunChain == null) {
-            return Collections.emptyList();
-        }
-        if (PASSES_FIELD == null) {
-            return Collections.emptyList();
-        }
-        try {
-            Object value = PASSES_FIELD.get(railgunChain);
-            if (value instanceof List<?> list) {
-                @SuppressWarnings("unchecked")
-                List<PostPass> passes = (List<PostPass>) list;
-                return passes;
-            }
-            ForgeOrbitalRailgunMod.LOGGER.error(
-                    "Orbital railgun post chain passes had unexpected type: {}",
-                    value == null ? "null" : value.getClass().getName()
-            );
-        } catch (IllegalAccessException exception) {
-            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
-            return Collections.emptyList();
-        }
-        return Collections.emptyList();
-    }
-
-    private static Field findPassesField() {
-        try {
-            return ObfuscationReflectionHelper.findField(PostChain.class, "passes");
-        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
-            try {
-                return ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
-            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
-                ForgeOrbitalRailgunMod.LOGGER.error(
-                        "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
-                        exception
-                );
-                return null;
-            }
-        }
-    }
-
-    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(matrix);
-        }
-    }
-
-    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set((float) vec.x, (float) vec.y, (float) vec.z);
-        }
-    }
-
-    private static void setVec2(EffectInstance effect, String name, float x, float y) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(x, y);
-        }
-    }
-
-    private static void setFloat(EffectInstance effect, String name, float value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void setInt(EffectInstance effect, String name, int value) {
-        Uniform uniform = effect.getUniform(name);
-        if (uniform != null) {
-            uniform.set(value);
-        }
-    }
-
-    private static void closeChain() {
-        if (railgunChain != null) {
-            try {
-                railgunChain.close();
-            } catch (Exception ignored) {
-            }
-            railgunChain = null;
-        }
-        chainReady = false;
-        chainWidth = -1;
-        chainHeight = -1;
     }
 }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ShaderModBridge.java
@@ -1,0 +1,63 @@
+package net.tysontheember.orbitalrailgun.client;
+
+import net.minecraftforge.fml.ModList;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public final class ShaderModBridge {
+    private static final boolean IRIS_LOADED = ModList.get().isLoaded("iris");
+    private static final boolean OCULUS_LOADED = ModList.get().isLoaded("oculus");
+
+    private static final MethodHandle IRIS_GET_INSTANCE;
+    private static final MethodHandle IRIS_IS_SHADER_PACK_IN_USE;
+
+    static {
+        MethodHandle getInstance = null;
+        MethodHandle isShaderPackInUse = null;
+
+        if (IRIS_LOADED) {
+            try {
+                Class<?> irisApiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+                MethodHandles.Lookup lookup = MethodHandles.lookup();
+                getInstance = lookup.findStatic(irisApiClass, "getInstance", MethodType.methodType(irisApiClass));
+                isShaderPackInUse = lookup.findVirtual(irisApiClass, "isShaderPackInUse", MethodType.methodType(boolean.class));
+            } catch (ReflectiveOperationException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.warn("Failed to initialise Iris reflection bridge", exception);
+                getInstance = null;
+                isShaderPackInUse = null;
+            }
+        }
+
+        IRIS_GET_INSTANCE = getInstance;
+        IRIS_IS_SHADER_PACK_IN_USE = isShaderPackInUse;
+    }
+
+    private ShaderModBridge() {
+    }
+
+    public static boolean isShaderPackInUse() {
+        if (!IRIS_LOADED && !OCULUS_LOADED) {
+            return false;
+        }
+        if (IRIS_GET_INSTANCE == null || IRIS_IS_SHADER_PACK_IN_USE == null) {
+            return false;
+        }
+        try {
+            Object instance = IRIS_GET_INSTANCE.invoke();
+            if (instance == null) {
+                return false;
+            }
+            return (boolean) IRIS_IS_SHADER_PACK_IN_USE.invoke(instance);
+        } catch (Throwable throwable) {
+            ForgeOrbitalRailgunMod.LOGGER.debug("Unable to query Iris shader state", throwable);
+            return false;
+        }
+    }
+
+    public static boolean isShaderModPresent() {
+        return IRIS_LOADED || OCULUS_LOADED;
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/railgun/PostChainManager.java
@@ -1,0 +1,412 @@
+package net.tysontheember.orbitalrailgun.client.railgun;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EffectInstance;
+import net.minecraft.client.renderer.PostChain;
+import net.minecraft.client.renderer.PostPass;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.ShaderModBridge;
+import net.tysontheember.orbitalrailgun.config.OrbitalRailgunClientConfig;
+import org.joml.Matrix4f;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public final class PostChainManager {
+    private static final ResourceLocation RAILGUN_CHAIN_ID = ForgeOrbitalRailgunMod.id("shaders/post/railgun.json");
+    private static final ResourceLocation COMPAT_OVERLAY_ID = ForgeOrbitalRailgunMod.id("shaders/post/compat_overlay.json");
+    private static final Set<ResourceLocation> MODEL_VIEW_UNIFORM_PASSES = Set.of(
+        ForgeOrbitalRailgunMod.id("strike"),
+        ForgeOrbitalRailgunMod.id("gui")
+    );
+
+    private static final Field PASSES_FIELD = findPassesField();
+
+    private static PostChain railgunChain;
+    private static EffectInstance compatOverlay;
+    private static boolean chainReady;
+    private static boolean overlayReady;
+    private static boolean compatibilityMode;
+    private static boolean disabledForShaderPack;
+    private static boolean shaderPackActive;
+    private static int chainWidth = -1;
+    private static int chainHeight = -1;
+    private static ResourceManager lastResourceManager;
+
+    static {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(PostChainManager::onRegisterReloadListeners);
+    }
+
+    private PostChainManager() {
+    }
+
+    private static void onRegisterReloadListeners(RegisterClientReloadListenersEvent event) {
+        event.registerReloadListener(new SimplePreparableReloadListener<Void>() {
+            @Override
+            protected Void prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
+                return null;
+            }
+
+            @Override
+            protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
+                reload(resourceManager);
+            }
+        });
+    }
+
+    public static void ensureState() {
+        Minecraft minecraft = Minecraft.getInstance();
+        ResourceManager resourceManager = lastResourceManager != null ? lastResourceManager : minecraft.getResourceManager();
+        if (resourceManager == null) {
+            return;
+        }
+
+        boolean shaderInUse = ShaderModBridge.isShaderPackInUse();
+        boolean disableWithShader = OrbitalRailgunClientConfig.CLIENT.compat.disableWithShaderpack.get();
+        boolean forceVanilla = OrbitalRailgunClientConfig.CLIENT.compat.forceVanillaPostChain.get();
+
+        boolean shouldCompatibility = shaderInUse && !forceVanilla && !disableWithShader;
+        boolean shouldDisable = shaderInUse && disableWithShader;
+
+        if (shaderInUse != shaderPackActive || shouldCompatibility != compatibilityMode || shouldDisable != disabledForShaderPack) {
+            reload(resourceManager);
+        }
+    }
+
+    private static void reload(ResourceManager resourceManager) {
+        Minecraft minecraft = Minecraft.getInstance();
+        lastResourceManager = resourceManager;
+        closeResources();
+
+        shaderPackActive = ShaderModBridge.isShaderPackInUse();
+        boolean disableWithShader = OrbitalRailgunClientConfig.CLIENT.compat.disableWithShaderpack.get();
+        boolean forceVanilla = OrbitalRailgunClientConfig.CLIENT.compat.forceVanillaPostChain.get();
+
+        compatibilityMode = shaderPackActive && !forceVanilla && !disableWithShader;
+        disabledForShaderPack = shaderPackActive && disableWithShader;
+
+        if (OrbitalRailgunClientConfig.CLIENT.compat.logIrisState.get() && ShaderModBridge.isShaderModPresent()) {
+            if (compatibilityMode) {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected: enabling compatibility mode");
+            } else if (disabledForShaderPack) {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected: disabling orbital railgun post effects");
+            } else if (shaderPackActive && forceVanilla) {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack detected: forcing vanilla orbital railgun post chain");
+            } else {
+                ForgeOrbitalRailgunMod.LOGGER.info("Shader pack compatibility not required");
+            }
+        }
+
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            chainReady = false;
+            overlayReady = false;
+            return;
+        }
+
+        if (disabledForShaderPack) {
+            return;
+        }
+
+        if (compatibilityMode) {
+            try {
+                compatOverlay = new EffectInstance(COMPAT_OVERLAY_ID);
+                overlayReady = true;
+            } catch (IOException exception) {
+                overlayReady = false;
+                compatOverlay = null;
+                ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun compatibility overlay", exception);
+            }
+            return;
+        }
+
+        try {
+            railgunChain = new PostChain(minecraft.getTextureManager(), resourceManager, mainTarget, RAILGUN_CHAIN_ID);
+            chainReady = true;
+            chainWidth = -1;
+            chainHeight = -1;
+            resizeChain(minecraft);
+        } catch (IOException exception) {
+            chainReady = false;
+            railgunChain = null;
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to load orbital railgun post chain", exception);
+        }
+    }
+
+    public static boolean isStageValid(RenderLevelStageEvent.Stage stage) {
+        if (compatibilityMode) {
+            return stage == RenderLevelStageEvent.Stage.AFTER_WEATHER;
+        }
+        return stage == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS;
+    }
+
+    public static boolean isReady() {
+        if (disabledForShaderPack) {
+            return false;
+        }
+        return compatibilityMode ? overlayReady : chainReady && railgunChain != null;
+    }
+
+    public static void resizeIfNeeded() {
+        if (compatibilityMode || railgunChain == null) {
+            return;
+        }
+        resizeChain(Minecraft.getInstance());
+    }
+
+    private static void resizeChain(Minecraft minecraft) {
+        if (railgunChain == null) {
+            return;
+        }
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+        int width = mainTarget.width;
+        int height = mainTarget.height;
+        if (width == chainWidth && height == chainHeight) {
+            return;
+        }
+        railgunChain.resize(width, height);
+        chainWidth = width;
+        chainHeight = height;
+    }
+
+    public static void render(RenderLevelStageEvent event, RailgunState state, boolean strikeActive, boolean chargeActive,
+                              float timeSeconds, Matrix4f projection, Matrix4f inverseProjection, Matrix4f modelView,
+                              Vec3 cameraPos, Vec3 targetPos, float distance, float isBlockHit) {
+        if (!isReady()) {
+            return;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        RenderTarget mainTarget = minecraft.getMainRenderTarget();
+        if (mainTarget == null) {
+            return;
+        }
+
+        float width = mainTarget.width > 0 ? mainTarget.width : mainTarget.viewWidth;
+        float height = mainTarget.height > 0 ? mainTarget.height : mainTarget.viewHeight;
+
+        if (compatibilityMode) {
+            if (!overlayReady || compatOverlay == null) {
+                return;
+            }
+            renderCompatibilityOverlay(mainTarget, width, height, timeSeconds, state, strikeActive, isBlockHit, distance,
+                projection, inverseProjection, modelView, cameraPos, targetPos);
+            return;
+        }
+
+        resizeChain(minecraft);
+        applyUniformsToPasses(projection, inverseProjection, modelView, cameraPos, targetPos, width, height,
+            timeSeconds, distance, isBlockHit, strikeActive, chargeActive, state);
+        railgunChain.process(event.getPartialTick());
+    }
+
+    private static void renderCompatibilityOverlay(RenderTarget mainTarget, float width, float height, float timeSeconds,
+                                                   RailgunState state, boolean strikeActive, float isBlockHit,
+                                                   float distance, Matrix4f projection, Matrix4f inverseProjection,
+                                                   Matrix4f modelView, Vec3 cameraPos, Vec3 targetPos) {
+        compatOverlay.setSampler("DiffuseSampler", mainTarget::getColorTextureId);
+        Matrix4f identity = new Matrix4f().identity();
+        setMatrix(compatOverlay, "ProjMat", identity);
+        setMatrix(compatOverlay, "ModelViewMat", identity);
+        setMatrix(compatOverlay, "InverseTransformMatrix", inverseProjection);
+        setVec3(compatOverlay, "CameraPosition", cameraPos);
+        setVec3(compatOverlay, "BlockPosition", targetPos);
+        setVec3(compatOverlay, "HitPos", targetPos);
+        setVec2(compatOverlay, "OutSize", width, height);
+        setFloat(compatOverlay, "iTime", clampTime(timeSeconds));
+        setFloat(compatOverlay, "Distance", distance);
+        setFloat(compatOverlay, "IsBlockHit", isBlockHit);
+        setFloat(compatOverlay, "StrikeActive", strikeActive ? 1.0F : 0.0F);
+        setFloat(compatOverlay, "SelectionActive", state.isCharging() ? 1.0F : 0.0F);
+        setInt(compatOverlay, "HitKind", state.getHitKind().ordinal());
+
+        RenderSystem.bindTexture(0);
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+
+        compatOverlay.apply();
+
+        BufferBuilder builder = Tesselator.getInstance().getBuilder();
+        builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+        builder.vertex(-1.0D, -1.0D, 0.0D).uv(0.0F, 0.0F).endVertex();
+        builder.vertex(1.0D, -1.0D, 0.0D).uv(1.0F, 0.0F).endVertex();
+        builder.vertex(1.0D, 1.0D, 0.0D).uv(1.0F, 1.0F).endVertex();
+        builder.vertex(-1.0D, 1.0D, 0.0D).uv(0.0F, 1.0F).endVertex();
+        BufferUploader.drawWithShader(builder.end());
+
+        compatOverlay.clear();
+
+        RenderSystem.disableBlend();
+        RenderSystem.depthMask(true);
+        RenderSystem.enableDepthTest();
+    }
+
+    private static float clampTime(float timeSeconds) {
+        return Math.max(0.0F, Math.min(timeSeconds, 120.0F));
+    }
+
+    private static void applyUniformsToPasses(Matrix4f projection, Matrix4f inverseProjection, Matrix4f modelView,
+                                              Vec3 cameraPos, Vec3 targetPos, float width, float height, float timeSeconds,
+                                              float distance, float isBlockHit, boolean strikeActive, boolean chargeActive,
+                                              RailgunState state) {
+        List<PostPass> passes = getPasses();
+        if (passes.isEmpty()) {
+            return;
+        }
+
+        for (PostPass pass : passes) {
+            EffectInstance effect = pass.getEffect();
+            if (effect == null) {
+                continue;
+            }
+
+            ResourceLocation passName = getPassName(pass);
+            boolean expectsModelViewMatrix = passName != null && MODEL_VIEW_UNIFORM_PASSES.contains(passName);
+
+            setMatrix(effect, "ProjMat", projection);
+            if (expectsModelViewMatrix) {
+                setMatrix(effect, "ModelViewMat", modelView);
+            }
+            setMatrix(effect, "InverseTransformMatrix", inverseProjection);
+            setVec3(effect, "CameraPosition", cameraPos);
+            setVec3(effect, "BlockPosition", targetPos);
+            setVec3(effect, "HitPos", targetPos);
+            setVec2(effect, "OutSize", width, height);
+            setFloat(effect, "iTime", timeSeconds);
+            setFloat(effect, "Distance", distance);
+            setFloat(effect, "IsBlockHit", isBlockHit);
+            setFloat(effect, "StrikeActive", strikeActive ? 1.0F : 0.0F);
+            setFloat(effect, "SelectionActive", chargeActive ? 1.0F : 0.0F);
+            setInt(effect, "HitKind", state.getHitKind().ordinal());
+        }
+    }
+
+    private static ResourceLocation getPassName(PostPass pass) {
+        String name = pass.getName();
+        return name != null ? ResourceLocation.tryParse(name) : null;
+    }
+
+    private static List<PostPass> getPasses() {
+        if (railgunChain == null || PASSES_FIELD == null) {
+            return Collections.emptyList();
+        }
+        try {
+            Object value = PASSES_FIELD.get(railgunChain);
+            if (value instanceof List<?> list) {
+                @SuppressWarnings("unchecked")
+                List<PostPass> passes = (List<PostPass>) list;
+                return passes;
+            }
+            ForgeOrbitalRailgunMod.LOGGER.error("Orbital railgun post chain passes had unexpected type: {}",
+                value == null ? "null" : value.getClass().getName());
+        } catch (IllegalAccessException exception) {
+            ForgeOrbitalRailgunMod.LOGGER.error("Failed to access orbital railgun post chain passes", exception);
+        }
+        return Collections.emptyList();
+    }
+
+    private static Field findPassesField() {
+        try {
+            Field field = ObfuscationReflectionHelper.findField(PostChain.class, "passes");
+            field.setAccessible(true);
+            return field;
+        } catch (ObfuscationReflectionHelper.UnableToFindFieldException ignored) {
+            try {
+                Field field = ObfuscationReflectionHelper.findField(PostChain.class, "f_110009_");
+                field.setAccessible(true);
+                return field;
+            } catch (ObfuscationReflectionHelper.UnableToFindFieldException exception) {
+                ForgeOrbitalRailgunMod.LOGGER.error(
+                    "Unable to find passes field on PostChain using Mojmap or SRG identifiers",
+                    exception
+                );
+                return null;
+            }
+        }
+    }
+
+    private static void setMatrix(EffectInstance effect, String name, Matrix4f matrix) {
+        if (effect == null) {
+            return;
+        }
+        if (matrix == null) {
+            return;
+        }
+        if (effect.getUniform(name) != null) {
+            effect.getUniform(name).set(matrix);
+        }
+    }
+
+    private static void setVec3(EffectInstance effect, String name, Vec3 vec) {
+        if (effect == null || vec == null || effect.getUniform(name) == null) {
+            return;
+        }
+        effect.getUniform(name).set((float) vec.x, (float) vec.y, (float) vec.z);
+    }
+
+    private static void setVec2(EffectInstance effect, String name, float x, float y) {
+        if (effect == null || effect.getUniform(name) == null) {
+            return;
+        }
+        effect.getUniform(name).set(x, y);
+    }
+
+    private static void setFloat(EffectInstance effect, String name, float value) {
+        if (effect == null || effect.getUniform(name) == null) {
+            return;
+        }
+        effect.getUniform(name).set(value);
+    }
+
+    private static void setInt(EffectInstance effect, String name, int value) {
+        if (effect == null || effect.getUniform(name) == null) {
+            return;
+        }
+        effect.getUniform(name).set(value);
+    }
+
+    private static void closeResources() {
+        if (railgunChain != null) {
+            try {
+                railgunChain.close();
+            } catch (Exception ignored) {
+            }
+            railgunChain = null;
+        }
+        if (compatOverlay != null) {
+            try {
+                compatOverlay.close();
+            } catch (Exception ignored) {
+            }
+            compatOverlay = null;
+        }
+        chainReady = false;
+        overlayReady = false;
+        chainWidth = -1;
+        chainHeight = -1;
+    }
+}

--- a/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunClientConfig.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/config/OrbitalRailgunClientConfig.java
@@ -1,0 +1,46 @@
+package net.tysontheember.orbitalrailgun.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+import org.apache.commons.lang3.tuple.Pair;
+
+public final class OrbitalRailgunClientConfig {
+    public static final ForgeConfigSpec CLIENT_SPEC;
+    public static final Client CLIENT;
+
+    static {
+        Pair<Client, ForgeConfigSpec> pair = new ForgeConfigSpec.Builder().configure(Client::new);
+        CLIENT = pair.getLeft();
+        CLIENT_SPEC = pair.getRight();
+    }
+
+    private OrbitalRailgunClientConfig() {
+    }
+
+    public static final class Client {
+        public final Compat compat;
+
+        private Client(ForgeConfigSpec.Builder builder) {
+            compat = new Compat(builder);
+        }
+    }
+
+    public static final class Compat {
+        public final ForgeConfigSpec.BooleanValue disableWithShaderpack;
+        public final ForgeConfigSpec.BooleanValue logIrisState;
+        public final ForgeConfigSpec.BooleanValue forceVanillaPostChain;
+
+        private Compat(ForgeConfigSpec.Builder builder) {
+            builder.push("compat");
+            disableWithShaderpack = builder
+                .comment("If true, the orbital railgun post-processing is fully disabled while a shader pack is active.")
+                .define("disableWithShaderpack", false);
+            logIrisState = builder
+                .comment("If true, logs whether an Iris/Oculus shader pack is detected when resources reload.")
+                .define("logIrisState", true);
+            forceVanillaPostChain = builder
+                .comment("If true, always use the vanilla post-processing chain even when a shader pack is active.")
+                .define("forceVanillaPostChain", false);
+            builder.pop();
+        }
+    }
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/post/compat_overlay.json
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    "minecraft:main"
+  ],
+  "passes": [
+    {
+      "name": "orbital_railgun:compat_overlay",
+      "intarget": "minecraft:main",
+      "outtarget": "minecraft:main"
+    }
+  ]
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.fsh
@@ -1,0 +1,52 @@
+#version 150
+
+in vec2 texCoord;
+
+uniform sampler2D DiffuseSampler;
+uniform vec2 OutSize;
+uniform float iTime;
+uniform float Distance;
+uniform float IsBlockHit;
+uniform float StrikeActive;
+uniform float SelectionActive;
+uniform int HitKind;
+
+out vec4 fragColor;
+
+float vignette(vec2 uv) {
+    vec2 centered = uv - vec2(0.5);
+    float dist = length(centered);
+    float falloff = smoothstep(0.7, 0.2, dist);
+    return falloff;
+}
+
+float crosshairGlow(vec2 uv) {
+    vec2 offset = abs(uv - vec2(0.5));
+    float line = max(0.0, 0.02 - min(offset.x, offset.y));
+    float pulse = 0.5 + 0.5 * sin(iTime * 3.0);
+    return line * pulse;
+}
+
+vec3 strikeColor() {
+    float kind = clamp(float(HitKind), 0.0, 3.0) / 3.0;
+    vec3 strikeTint = mix(vec3(0.15, 0.45, 1.0), vec3(1.0, 0.55, 0.1), kind);
+    return strikeTint;
+}
+
+void main() {
+    vec4 base = texture(DiffuseSampler, texCoord);
+    float overlayStrength = max(StrikeActive * 0.85, SelectionActive * 0.6);
+    if (overlayStrength <= 0.0001) {
+        fragColor = base;
+        return;
+    }
+
+    float vignetteMask = vignette(texCoord) * overlayStrength;
+    float glow = crosshairGlow(texCoord) * overlayStrength;
+    float strikePulse = 0.35 + 0.65 * sin(iTime * 2.0);
+    float hitBoost = mix(0.0, 0.75, clamp(IsBlockHit, 0.0, 1.0));
+    vec3 tint = strikeColor();
+
+    vec3 overlay = tint * (vignetteMask * strikePulse + glow + hitBoost);
+    fragColor = vec4(base.rgb + overlay, 1.0);
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.json
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.json
@@ -1,0 +1,68 @@
+{
+  "name": "orbital_railgun:compat_overlay",
+  "vertex": "orbital_railgun:compat_overlay",
+  "fragment": "orbital_railgun:compat_overlay",
+  "samplers": [
+    {
+      "name": "DiffuseSampler"
+    }
+  ],
+  "attributes": [
+    "Position",
+    "UV0"
+  ],
+  "uniforms": [
+    {
+      "name": "ProjMat",
+      "type": "matrix4x4"
+    },
+    {
+      "name": "ModelViewMat",
+      "type": "matrix4x4"
+    },
+    {
+      "name": "InverseTransformMatrix",
+      "type": "matrix4x4"
+    },
+    {
+      "name": "CameraPosition",
+      "type": "float3"
+    },
+    {
+      "name": "BlockPosition",
+      "type": "float3"
+    },
+    {
+      "name": "HitPos",
+      "type": "float3"
+    },
+    {
+      "name": "OutSize",
+      "type": "float2"
+    },
+    {
+      "name": "iTime",
+      "type": "float"
+    },
+    {
+      "name": "Distance",
+      "type": "float"
+    },
+    {
+      "name": "IsBlockHit",
+      "type": "float"
+    },
+    {
+      "name": "StrikeActive",
+      "type": "float"
+    },
+    {
+      "name": "SelectionActive",
+      "type": "float"
+    },
+    {
+      "name": "HitKind",
+      "type": "int"
+    }
+  ]
+}

--- a/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.vsh
+++ b/src/main/resources/assets/orbital_railgun/shaders/program/compat_overlay.vsh
@@ -1,0 +1,14 @@
+#version 150
+
+in vec3 Position;
+in vec2 UV0;
+
+uniform mat4 ProjMat;
+uniform mat4 ModelViewMat;
+
+out vec2 texCoord;
+
+void main() {
+    texCoord = UV0;
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+}


### PR DESCRIPTION
## Summary
- register a new client config and shader bridge helpers to detect Iris/Oculus packs
- move post-processing to a dedicated manager that supports compatibility overlays and logs shader state
- add a lightweight compat overlay shader program to render railgun effects after shader packs finish compositing

## Testing
- ⚠️ `./gradlew compileJava` *(fails: wrapper script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e1920a251c83259a4035d35b93ed33