### PR TITLE
Fix shader registration and resource handling

### DIFF
--- a/src/main/java/net/tysontheember/orbitalrailgun/client/ClientInit.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/ClientInit.java
@@ -1,11 +1,18 @@
 package net.tysontheember.orbitalrailgun.client;
 
-import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormat;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.client.event.RegisterShadersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
+import net.tysontheember.orbitalrailgun.client.fx.RailgunFxRenderer;
+
+import java.io.IOException;
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = ForgeOrbitalRailgunMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
@@ -15,5 +22,22 @@ public final class ClientInit {
     @SubscribeEvent
     public static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
         // Intentionally empty. The Fabric version did not use custom keybinds.
+    }
+
+    @SubscribeEvent
+    public static void onRegisterShaders(RegisterShadersEvent event) throws IOException {
+        var resourceProvider = event.getResourceProvider();
+        event.registerShader(
+            new ShaderInstance(resourceProvider, new ResourceLocation("orbital_railgun", "orbital_screen_distort"), DefaultVertexFormat.POSITION),
+            shader -> RailgunFxRenderer.SCREEN_DISTORT = shader
+        );
+        event.registerShader(
+            new ShaderInstance(resourceProvider, new ResourceLocation("orbital_railgun", "orbital_screen_tint"), DefaultVertexFormat.POSITION),
+            shader -> RailgunFxRenderer.SCREEN_TINT = shader
+        );
+        event.registerShader(
+            new ShaderInstance(resourceProvider, new ResourceLocation("orbital_railgun", "orbital_beam"), DefaultVertexFormat.POSITION),
+            shader -> RailgunFxRenderer.BEAM = shader
+        );
     }
 }

--- a/src/main/java/net/tysontheember/orbitalrailgun/client/fx/RailgunRenderTypes.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/client/fx/RailgunRenderTypes.java
@@ -2,11 +2,17 @@ package net.tysontheember.orbitalrailgun.client.fx;
 
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
-import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.ShaderInstance;
+
+import java.util.function.Supplier;
 
 public final class RailgunRenderTypes extends RenderType {
+    private static final Supplier<ShaderInstance> SCREEN_DISTORT_SUP = () -> RailgunFxRenderer.SCREEN_DISTORT;
+    private static final Supplier<ShaderInstance> SCREEN_TINT_SUP = () -> RailgunFxRenderer.SCREEN_TINT;
+    private static final Supplier<ShaderInstance> BEAM_SUP = () -> RailgunFxRenderer.BEAM;
+
     public static final RenderType SCREEN_FX_DISTORT = RenderType.create(
         "orbital_screen_fx_distort",
         DefaultVertexFormat.POSITION,
@@ -15,7 +21,7 @@ public final class RailgunRenderTypes extends RenderType {
         false,
         false,
         RenderType.CompositeState.builder()
-            .setShaderState(new ShaderStateShard(() -> GameRenderer.getShader("orbital_railgun:orbital_screen_distort")))
+            .setShaderState(new RenderStateShard.ShaderStateShard(SCREEN_DISTORT_SUP))
             .setTransparencyState(RenderStateShard.ADDITIVE_TRANSPARENCY)
             .createCompositeState(false)
     );
@@ -28,22 +34,23 @@ public final class RailgunRenderTypes extends RenderType {
         false,
         false,
         RenderType.CompositeState.builder()
-            .setShaderState(new ShaderStateShard(() -> GameRenderer.getShader("orbital_railgun:orbital_screen_tint")))
-            .setTransparencyState(RenderStateShard.ADDITIVE_TRANSPARENCY)
+            .setShaderState(new RenderStateShard.ShaderStateShard(SCREEN_TINT_SUP))
+            .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
             .createCompositeState(false)
     );
 
     public static final RenderType BEAM_ADDITIVE = RenderType.create(
         "orbital_beam_additive",
         DefaultVertexFormat.POSITION,
-        VertexFormat.Mode.TRIANGLES,
+        VertexFormat.Mode.QUADS,
         256,
         false,
         false,
         RenderType.CompositeState.builder()
-            .setShaderState(new ShaderStateShard(() -> GameRenderer.getShader("orbital_railgun:orbital_beam")))
+            .setShaderState(new RenderStateShard.ShaderStateShard(BEAM_SUP))
             .setTransparencyState(RenderStateShard.ADDITIVE_TRANSPARENCY)
-            .setCullState(NO_CULL)
+            .setDepthTestState(RenderStateShard.LEQUAL_DEPTH_TEST)
+            .setWriteMaskState(RenderStateShard.COLOR_WRITE)
             .createCompositeState(false)
     );
 

--- a/src/main/java/net/tysontheember/orbitalrailgun/util/ShaderpackBridgeExporter.java
+++ b/src/main/java/net/tysontheember/orbitalrailgun/util/ShaderpackBridgeExporter.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.storage.LevelResource;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import net.tysontheember.orbitalrailgun.ForgeOrbitalRailgunMod;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,7 +34,8 @@ public final class ShaderpackBridgeExporter {
         }
 
         String safeName = normalized.replaceAll("[^A-Za-z0-9-_]", "_");
-        Path serverDir = server.getServerDirectory();
+        File serverDirectory = server.getServerDirectory();
+        Path serverDir = serverDirectory != null ? serverDirectory.toPath() : null;
         if (serverDir == null) {
             serverDir = server.getWorldPath(LevelResource.ROOT);
         }


### PR DESCRIPTION
## Summary
- register screen and beam shaders through RegisterShadersEvent and expose shader handles in RailgunFxRenderer
- update render types to use shader suppliers and adjust camera vector math to avoid Vector3f scaling
- resolve shaderpack bridge export paths via Path conversion

## Testing
- Not run (Gradle wrapper script missing in repository)


------
https://chatgpt.com/codex/tasks/task_e_68e2aa5a31d88325a5eaaee6dca2fb58